### PR TITLE
Bring back travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,62 @@
 sudo: true
 dist: trusty
-notifications:
-  email:
-    recipients:
-    - kunstrasenspringer@gmx.net
-    - kunstrasenspringer@googlemail.com
-    on_success: never
-    on_failure: always
+language: python
+python:
+  - "3.5"
+services:
+  - docker
 jobs:
   include:
   - stage: Building preCICE
+    name: "Ubuntu 16.04"
     script:
-    - docker build -f Dockerfile.precice -t precice .
+    - docker build -f Dockerfile.Ubuntu1604 -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
-    - docker tag precice $DOCKER_USERNAME/precice
-    - docker push $DOCKER_USERNAME/precice
+    - docker tag precice $DOCKER_USERNAME/precice_ubuntu1604
+    - docker push $DOCKER_USERNAME/precice_ubuntu1604
+
+  - stage: Building preCICE
+    name: "Ubuntu 18.04"
+    script:
+    - docker build -f Dockerfile.Ubuntu1804 -t precice .
+    after_success:
+    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - docker images
+    - docker tag precice $DOCKER_USERNAME/precice_ubuntu1804
+    - docker push $DOCKER_USERNAME/precice_ubuntu1804
+
   - stage: System Tests
     script:
     - python system_testing.py -s su2-ccx
+    name: "[16.04] SU2 <-> Calculix"
     after_success:
     - python push.py -s -t su2-ccx
     after_failure:
     - python push.py -t su2-ccx
   - script:
     - python system_testing.py -s of-of
+    name: "[16.04] OpenFOAM <-> OpenFOAM"
     after_success:
     - python push.py -s -t of-of
     after_failure:
     - python push.py -t of-of
   - script:
     - python system_testing.py -s of-ccx
+    name: "[16.04] Calculix <-> OpenFOAM"
     after_success:
     - python push.py -s -t of-ccx
     after_failure:
     - python push.py -t of-ccx
+  - script:
+    - python system_testing.py -s bindings
+    name: "[16.04] Python bindings"
+    after_success:
+    - python push.py -s -t bindings
+    after_failure:
+    - python push.py -t bindings
+
 env:
   global:
-  - secure: b4FQhQOaD/lE0FkV8gpPrjt8tqhyodOl3xKYc1wYKWjKBmJTV1SmwfeQW08rdBBdBETKuvd5dC8FAJ8zS3RaxLbFd/pT//9Uew9qFoG//faASqjzHK57m2BA0N/vt+0kyesbn+D1NNCPCOQhnohJqzF87beZnUQZDRWo1ueWG06K/4oCrdDcEKLjKZy/1a0dBR/gFV/4Ae/YFUhO14MN4+g53F5ZyrBiikEn8tv3dg+/NFVCfb9Dy7UC4J91f4+30wwysK/UIW2oZNrXyQldpa7BEzG5PsglZu1p3qebEeZfesemlR85nZA8O/pH0sVVk7FvxbQ7PSsfG5zU7hxNBCiIHKT0WqUDI75uCF0Z0uezFqwPM5CflpN1nCseh0FFKKWcrYQr/Vf2cQL2ItsBO7rjw7BmLAyWJ/1kIMs6YTOOhoN2iEqAxn9lZX6M3RJMF9UivfqnPsOPSJGf5ySIoLKix3bHdX5gGF4ojjqyy9WwPxgtnjQjxSq2u/WUcEitH3J4T2h35t4UlgO7Zvv2oYZeXWNSi4ZTogGvA5KNOAYPUncaJmhNZil2cXFEyX3G02745MY4d7QZHyylYC8k+YdrWNMp3b8rl6C5KBJnjSJ3edkLxAU6DYFfCmFfzfNdN+FuhG9A4Ueq2DEw7oZVL5LQ7cqXQ/oTTaLO0cbZ76k=
+     secure: "vQ1bL5Z0kPvm0/rXMmU7nOSpqPCtQuew0AaRnpKdiEX2U1xqebCaeA88pDQaXONa14dSsP3bYidVjETh4kzggwVnEtr7lqVUDMTNxekHr8rcojRi/+x7uhJZ7VhabEpEWNKesen8Gcqf5+LlaEkStc2gf2HxAzNge8qjxrk3I5JuxpRBSjgtvIIaD4Dw9YSShSGqHW4wGkqsQ6DTLccmzk3tmvuSYrifGAuc0luk+kYJJn3SGDfEEbIenSGBn5Z5IkPmEcQmQnL67OdXWwUW/QMBBE3d8xpZpr6vt/a8txF5v6d8eJ/I3jIUrrLSY2/RRFC7CORG2rrW758d+SluzUGRc+6MPJFiXyay4CUa2eaWiuYoDtnfTqF5zqaQTATZRYszJu75yGJazcQBFK4WWqMSnSBjxqRKSgjfnjfAFUiqDfpxcLaLDb2UUQWH681aDtQEbkon/E7fIlDkheiXFOccmaZfh0Ydrsj1Sb41HkfzCDm95D3YvHm2fqUhjkYAHw6EFn7yaV1i+xgo9Xs2IRmtlbYo4pe8IJ06bjRFihX+6udBFeioO9F+gNTc88YbwsQfjVpMjc7IhuOWyAjKw8NjL0DPhXDC3iRILhRsuGUMc1uD1Vf73MQOGTaM5ITtdCYDBF3p/9kfWqNMUXS7K+bLK28bW6bnyWRQKMHAb60="

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Python script to compare reference data with output data.
 - log_*: script to log infomation about the build
 
 # Status
-[![Build Status](https://travis-ci.org/kunstrasenspringer/precice_st.svg?branch=develop)](https://travis-ci.org/kunstrasenspringer/precice_st)
+[![Build Status](https://travis-ci.org/precice/systemtests.svg?branch=develop)](https://travis-ci.org/precice/systemtests)
 
 # How to create a new system tests
 1. Create a directory `Test_mysystemtest`.

--- a/Test_of-ccx.Ubuntu1604/Dockerfile
+++ b/Test_of-ccx.Ubuntu1604/Dockerfile
@@ -1,7 +1,7 @@
 # System testing preCICE with openfoam-adapter and calculix-adapter
 
 # Building on top of the latets preCICE-build
-ARG from=kunstrasenspringer/precice:latest
+ARG from=precicecoupling/precice:latest
 FROM $from
 
 USER root

--- a/Test_of-of.Ubuntu1604/Dockerfile
+++ b/Test_of-of.Ubuntu1604/Dockerfile
@@ -1,7 +1,7 @@
 # System testing preCICE with openfoam-adapter
 
 # Using latest preCICE from dockerhub.com
-ARG from=kunstrasenspringer/precice:latest
+ARG from=precicecoupling/precice:latest
 FROM $from
 
 USER root

--- a/Test_su2-ccx.Ubuntu1604/Dockerfile
+++ b/Test_su2-ccx.Ubuntu1604/Dockerfile
@@ -1,7 +1,7 @@
 # System testing preCICE with SU2-adapter and calculix-adapter
 
 # Building on top of the latest preCICE-build
-ARG from=kunstrasenspringer/precice:latest
+ARG from=precicecoupling/precice:latest
 FROM $from
 
 USER root

--- a/common.py
+++ b/common.py
@@ -9,7 +9,10 @@ def call(cmd, **kwargs):
 def ccall(cmd,  **kwargs):
     """ Runs cmd in a shell, returns its return code. Raises exception on error """
     return call(cmd, check = True, **kwargs)
-    
+
+def capture_output(cmd, **kwargs):
+    """ Runs cmd in a shell and captures output """
+    return subprocess.run(cmd, stdout=subprocess.PIPE, **kwargs).stdout.decode('utf-8')
 
 import os
 


### PR DESCRIPTION
#### General approach: 

* All tests are run on Ubuntu 16.04 ( Ubuntu 18.04 will come in separate PR)
* During "Build stage", preCICE images are built and pushed to the [dockerhub](https://hub.docker.com/u/precicecoupling). 
* During "System tests" stage, all tests are executed, and results are pushed  to the [ precice_st_output ](https://github.com/precice/precice_st_output) repository. In case of succesful execution,  only the log file, with name of the system_test, time, commit hashes, etc is pushed. The clickable link to the travis job  is in the commit message, for the reference. 
  If results are different from the `referenceOutput` also folder with results is commited.  If the job fails during building of the adapter we detect it and write corresponding commit message as well. 

  In order to distinguish between different cases that fail, result are pushed either to 'Ubuntu1604' 
  or 'Ubuntu1804' folder. Inside those, the  folder with the output has name as 'Output_$system_test_name'  
  If the next build fixes previously broken test, output folder is deleted. Similarly, it is ensured, that different    wrong results are not mixed. ( E.g. if the tests fails, produces wrong output and the next commit produces *different* wrong output, only latest wrong output stays in the repository ). 

* The tests should probably be run nightly as a cron job

 You have a look at  repository with the output to get a feeling of the structure [in this repo]( https://github.com/precice/precice_st_output ). 
Sample job build ( I already enabled  Travis to test on other branch ) is [here](https://travis-ci.org/precice/systemtests/builds/475788595).
