### PR TITLE
Allow adapter to trigger custom systemtests build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ Python script to compare reference data with output data.
 2. Create a `Dockerfile` in there.
 3. Create a directory `referenceOutput` there.
 4. Copy the output files to a folder `/Output/` (inside the container).
+
+# Adding CI to a new adapter
+
+As described in [#22](https://github.com/precice/systemtests/pull/22),  using `trigger_systemtests.py` it is possible to trigger custom systemtests from the travis job of the another adapter, therefore providing continous integration for the adapter on each commit to a particular branch. If you want to add another adapter, or modify tests that are run for it, you need to modify `nm_repo_map` and `nm_test_map` variables in the `trigger_systemtests.py`, that describe mapping between adapter name and repository and adapter name and set of test cases correspondingly.
+
+The adapter's Travis build would be considered successful if systemtests Travis build exits with status 'Failed' or 'Errored'. It would exit with 'Success', if the systemtests Travis build exits with 'Success' or 'Canceled'.

--- a/trigger_systemtests.py
+++ b/trigger_systemtests.py
@@ -7,6 +7,8 @@
 
 import json
 import os
+import time
+from sys import exit
 import argparse
 from string import Template
 from urllib.parse import urlencode
@@ -22,13 +24,35 @@ nm_test_map = {'openfoam': ['of-of', 'of-ccx'],
         'su2': ['su2-ccx'] }
 
 
-def generate_travis_job(adapter, user):
+def get_json_response(url, **kwargs):
+
+    headers = {
+      "Content-Type" : "application/json",
+      "Accept": "application/json",
+      "Travis-API-Version": "3",
+      "Authorization": "token {}".format(os.environ['TRAVIS_ACCESS_TOKEN'])
+    }
+
+    req = Request(url, headers = headers, **kwargs )
+    response = urlopen( req ).read().decode()
+    json_response = json.loads( response )
+
+    return json_response
+
+def generate_travis_job(adapter, user, trigger_failure = True):
+
+    triggered_by = os.environ["TRAVIS_JOB_WEB_URL"] if "TRAVIS_JOB_WEB_URL" in\
+         os.environ else "manual script call"
+
+    after_failure_action = "python push.py -t $TEST;"
+    if trigger_failure:
+        after_failure_action += " python trigger_systemtests.py --failure --owner $USER --adapter $ADAPTER"
 
     job_templates= {
         "name":  Template('[16.04] $TESTNAME <-> $TESTNAME'),
         "script": Template('python system_testing.py -s $TEST') ,
         "after_success":Template('python push.py -s -t $TEST') ,
-        "after_failure": Template("python push.py -t $TEST; python trigger_systemtests.py --failure --owner $USER --adapter $ADAPTER")}
+        "after_failure": Template(after_failure_action)}
 
     job_body={
         "request": {
@@ -60,7 +84,7 @@ def generate_travis_job(adapter, user):
                 ADAPTER=adapter)
         jobs.append(job)
 
-    job_body["request"]["message"] = adapter + ' systemtest'
+    job_body["request"]["message"] = "{} systemtest. Triggered by:{}".format(adapter, triggered_by)
     job_body["request"]["config"]["jobs"]["include"] = jobs;
 
     return job_body
@@ -74,16 +98,64 @@ def trigger_travis_build(job_body, user, repo):
     url = "https://api.{TRAVIS_URL}/repo/{USER}%2F{REPO}/requests".format(TRAVIS_URL="travis-ci.org",
         USER=user,REPO=repo)
 
-    headers = {
-      "Content-Type" : "application/json",
-      "Accept": "application/json",
-      "Travis-API-Version": "3",
-      "Authorization": "token {}".format(os.environ['TRAVIS_ACCESS_TOKEN'])
-    }
-
     data = json.dumps(job_body).encode('utf8')
-    req = Request(url, headers = headers, data = data)
-    response = urlopen(req ).read().decode()
+
+    return get_json_response(url, data = data)
+
+def check_job_status(job_id):
+    """ Checks status of the travis job"""
+    url = "https://api.{TRAVIS_URL}/build/{JOB_ID}".format(TRAVIS_URL="travis-ci.org", JOB_ID=job_id)
+
+    resp =  get_json_response(url)
+    return resp['state']
+
+def get_requests(user, repo):
+
+    url = "https://api.{TRAVIS_URL}/repo/{USER}%2F{REPO}/requests".format(TRAVIS_URL="travis-ci.org",
+            USER=user, REPO=repo )
+    return get_json_response(url)
+
+def query_request_info(user, repo, req_id):
+
+    url = "https://api.{TRAVIS_URL}/repo/{USER}%2F{REPO}/request/{REQUEST_ID}".format(TRAVIS_URL="travis-ci.org",
+            USER=user, REPO=repo, REQUEST_ID=req_id)
+    return get_json_response(url)
+
+def trigger_travis_and_wait_and_respond(job_body, user, repo):
+
+    json_response = trigger_travis_build(job_body, user, repo)
+    request_id = json_response['request']['id']
+
+    request_info = query_request_info(user, repo, request_id)
+    # it case request is being processes slow for whatever reasons
+    # (e.g) multiple requests were triggered, we don't yet have
+    # info about job_id, so we'll wait until we have it
+    print ("Request pending..")
+    while request_info.get('state') == 'pending':
+        # for ther reference in case of failures
+        print ("Current request status is {}".format(request_info['state']))
+        request_info = query_request_info(user, repo, request_id)
+        time.sleep(60)
+
+    if request_info["result"] != "approved":
+        raise Exception("Systemtest build request did not get approved")
+
+    job_id = request_info['builds'][0]['id']
+
+    job_status = ''
+    success_status = ["passed", "canceled"]
+    failed_status = ["errored", "failed"]
+
+    print ("Job started..")
+    while not job_status in (success_status + failed_status):
+        job_status = check_job_status(job_id)
+        print ("Current job status is {}. Be patient...".format(job_status))
+        time.sleep(60)
+
+    if job_status in success_status:
+        exit(0)
+    else:
+        exit(1)
 
 
 def generate_failure_callback():
@@ -91,9 +163,11 @@ def generate_failure_callback():
     running anything
     """
 
+    triggered_by = os.environ["TRAVIS_JOB_WEB_URL"];
+
     callback_body={
     "request": {
-      "message": "Systemtests failed",
+     "message": "Systemtests failed. Build url:{}".format(triggered_by),
       "branch": "master",
         "config": {
           "merge_mode": "replace",
@@ -114,16 +188,22 @@ def generate_failure_callback():
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Generate and trigger job for systemtests")
-    parser.add_argument('--owner',  type=str, help="Owner of repository", default='precice' )
+    parser.add_argument('--owner',  type=str, help="Owner of repository", default='shkodm' )
     parser.add_argument('--adapter', type=str, help="Adapter for which you want to trigger systemtests",
               required=True, choices = ["openfoam", "su2", "calculix"])
     parser.add_argument('--failure', help="Whether to trigger normal or failure build",
               action="store_true")
+    parser.add_argument('--wait', help='Whether exit only when the triggered build succeeds',
+              action='store_true')
     args = parser.parse_args()
 
     if args.failure:
         repo = nm_repo_map[ args.adapter ]
         trigger_travis_build( generate_failure_callback(), args.owner,repo)
     else:
-        trigger_travis_build( generate_travis_job(args.adapter, args.owner),
-                     args.owner, 'systemtests' )
+        if args.wait:
+            trigger_travis_and_wait_and_respond(generate_travis_job(args.adapter, args.owner, trigger_failure
+                = False), args.owner, 'systemtests' )
+        else:
+            trigger_travis_build( generate_travis_job(args.adapter, args.owner),
+                         args.owner, 'systemtests' )

--- a/trigger_systemtests.py
+++ b/trigger_systemtests.py
@@ -1,0 +1,129 @@
+"""
+ Generate Travis API V3 request to trigger corresponding systemtests
+ based on the adapter type. To adjust it for newly added system test modify
+ dictionaries "nm_repo_map" and "np_test_map" below with the name of the
+ adapter repository and systemtests that should be run for it.
+"""
+
+import json
+import os
+import argparse
+from string import Template
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+nm_repo_map = {'openfoam': 'openfoam-adapter',
+    'calculix' : 'calculix-adapter',
+    'su2': 'su2-adapter'}
+
+
+nm_test_map = {'openfoam': ['of-of', 'of-ccx'],
+        'calculix': ['of-ccx', 'su2-ccx'],
+        'su2': ['su2-ccx'] }
+
+
+def generate_travis_job(adapter, user):
+
+    job_templates= {
+        "name":  Template('[16.04] $TESTNAME <-> $TESTNAME'),
+        "script": Template('python system_testing.py -s $TEST') ,
+        "after_success":Template('python push.py -s -t $TEST') ,
+        "after_failure": Template("python push.py -t $TEST; python trigger_systemtests.py --failure --owner $USER --adapter $ADAPTER")}
+
+    job_body={
+        "request": {
+          "message": "{} systemtests".format(adapter),
+          "branch": "master",
+          "config": {
+            # we need to use 'replace' to replace .travis.yml,
+            # that is originally present in the repo
+            "merge_mode": "replace",
+            "sudo": "true",
+            "dist": "trusty",
+            "language": "python",
+            "services": "docker",
+            "python": "3.5",
+            "jobs":  {
+              "include":[
+                ]
+              }
+            }
+          }
+        }
+
+    # generate jobs body for the request
+    jobs = []
+    for tests in nm_test_map[adapter]:
+        job = {}
+        for key,template in job_templates.items():
+            job[key] = template.substitute(TESTNAME=tests, USER=user, TEST=tests,
+                ADAPTER=adapter)
+        jobs.append(job)
+
+    job_body["request"]["message"] = adapter + ' systemtest'
+    job_body["request"]["config"]["jobs"]["include"] = jobs;
+
+    return job_body
+
+
+def trigger_travis_build(job_body, user, repo):
+    """ Trigger custom travis build using "job_body" as specification
+    in the user/repo using Travis API V3
+    """
+
+    url = "https://api.{TRAVIS_URL}/repo/{USER}%2F{REPO}/requests".format(TRAVIS_URL="travis-ci.org",
+        USER=user,REPO=repo)
+
+    headers = {
+      "Content-Type" : "application/json",
+      "Accept": "application/json",
+      "Travis-API-Version": "3",
+      "Authorization": "token {}".format(os.environ['TRAVIS_ACCESS_TOKEN'])
+    }
+
+    data = json.dumps(job_body).encode('utf8')
+    req = Request(url, headers = headers, data = data)
+    response = urlopen(req ).read().decode()
+
+
+def generate_failure_callback():
+    """ Generates travis job body, that simply fails without
+    running anything
+    """
+
+    callback_body={
+    "request": {
+      "message": "Systemtests failed",
+      "branch": "master",
+        "config": {
+          "merge_mode": "replace",
+          "sudo": "true",
+          "dist": "trusty",
+          "jobs": {
+          "include":{
+              "name": "Systemtest failure callback",
+              "script": "false"
+            }
+          }
+        }
+    }}
+
+    return callback_body
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description="Generate and trigger job for systemtests")
+    parser.add_argument('--owner',  type=str, help="Owner of repository", default='precice' )
+    parser.add_argument('--adapter', type=str, help="Adapter for which you want to trigger systemtests",
+              required=True, choices = ["openfoam", "su2", "calculix"])
+    parser.add_argument('--failure', help="Whether to trigger normal or failure build",
+              action="store_true")
+    args = parser.parse_args()
+
+    if args.failure:
+        repo = nm_repo_map[ args.adapter ]
+        trigger_travis_build( generate_failure_callback(), args.owner,repo)
+    else:
+        trigger_travis_build( generate_travis_job(args.adapter, args.owner),
+                     args.owner, 'systemtests' )

--- a/trigger_systemtests.py
+++ b/trigger_systemtests.py
@@ -188,7 +188,7 @@ def generate_failure_callback():
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Generate and trigger job for systemtests")
-    parser.add_argument('--owner',  type=str, help="Owner of repository", default='shkodm' )
+    parser.add_argument('--owner',  type=str, help="Owner of repository", default='precice' )
     parser.add_argument('--adapter', type=str, help="Adapter for which you want to trigger systemtests",
               required=True, choices = ["openfoam", "su2", "calculix"])
     parser.add_argument('--failure', help="Whether to trigger normal or failure build",


### PR DESCRIPTION
**NOTICE**: This should be merged (hopefully) only after #21.  Also one should probably read that PR, before reading this. 

## Problem

 Even when having daily cron-job based builds with Travis several problems might occur. What if in one day several commits were pushed to adapters ( or maybe also preCICE itself ). I know, I know, some adapters are not in active development, but from what I can see some are (e.g.  [openfoam-adapter](https://github.com/precice/openfoam-adapter) ). Then daily build fails, wrong results or failure during building is produced and one has to manually dig through the series of changes in the adapter to find out which one exactly caused the problem. This is not nice. 

Reasoning above should suggest, that some kind of more continuous integration should exist for adapters also ( at least for the master branch ). But we already have the tests for adapters in this repository, that are integrated nicely with Travis ( after #21 ). Can we somehow reuse this functionality for adapters? Of course, we don't want to run full systemtests suite, with all the adapters and additional building of preCICE, but lets say we just use already pushed to dockerhub preCICE image (so that tests will be executed fast enough) and only tests that are related to the adapter are run (e.g. for OpenFOAM we test OpenFOAM-OpenFOAM and OpenFOAM-Calculix, but for SU2 just SU2-Calculix ). How to achieve it with least effort, no code duplication and make sure it is robust and useful? 

## Solution 

Turns out we can use [Travis API v3]( https://docs.travis-ci.com/user/triggering-builds/) to make dependent builds, i.e. we can trigger `systemtests` Travis build during execution of Travis build of e.g. openFOAM adapter. This way we can make integration *continuous*, so new commits on adapters are checked. Now, to make sure, with this customly triggered builds, that only set of tests related to adapter is executed and we do not do any extra work, we can use more features of Travis API, namely use custom job bodies ( and send them via API request as JSON). However, this is not enough, since the maintainers of the adapter ( and the 'passing' or 'fail' badge in the `README.md`...) need to be informed, and we want to keep history of failures of the adapters in its own Travis page. To do this we can again use dependent builds, now making systemtests build trigger custom build of the adapter, that just fails, if the systemtests failed. This way adapter gets to know that it failed, and if desired can find reference output in the [precice_st_output](https://github.com/precice/precice_st_output)

Since build configuration of this custom Travis jobs are pretty similar, with only difference being names of tests to run, names of repositories, etc., we can write general python script that can send triggering of different systemtests (and corresponding failure callback) from different adapter and allows easy addition of new ones. 

Then the only thing remaining is to add `.travis.yml`  to the adapter, which (excluding system specs can be very simple) 
```yml
    - if: branch = master
      script: |
        curl -LO --retry 3 https://raw.githubusercontent.com/precice/systemtests/master/trigger_systemtests.py
        python trigger_systemtests.py --adapter openfoam
``` 
And of course, we need to add `TRAVIS_ACCESS_TOKEN` in each adapter repository as a secure variable, to be used as authentication when triggering Travis with API. But this is not a big price to pay. 

To illustrate, the solution above, following will be executed on commit to OpenFOAM adapter master branch: 

1) Travis starts building openFOAM adapter, send trigger request to systemtests and exits with success 
![image](https://user-images.githubusercontent.com/13331189/50742076-b2c6fd80-1206-11e9-93c7-67641f480324.png)
                                                               *openfoam-adapter travis page*

2) Travis starts building systemtests using custom job recipe, that was just sent, runs OpenFOAM-OpenFOAM, OpenFOAM-CalculiX, if everything is fine exits with success, otherwise pushes wrong output and logfile to the output repository and triggers custom Travis build of OpenFOAM
![image](https://user-images.githubusercontent.com/13331189/50742048-6f6c8f00-1206-11e9-9aa3-2c04a1ecd68c.png)
                                                 *systemtests travis page (note that only openfoam related tests  are run)* 

3) (If systemtests failed) Travis starts building OpenFOAM, and since the request was just to fail, it fails. Fin. 
![image](https://user-images.githubusercontent.com/13331189/50741931-9033e500-1204-11e9-9b17-c76cf81073d7.png)
                                                             *openfoam-adapter travis page*


In this PR I add `trigger_systemtests.py`, that does all of the above. I already tested it on my fork of the Calculix, OpenFOAM, and SU2 adapters. Discussion and suggestions what else can be improved are welcome. 