### PR TITLE
Update openfoam configuration files in reference

### DIFF
--- a/Test_of-ccx.Ubuntu1604/referenceOutput/Inner-Fluid/precice-adapter-config.yml
+++ b/Test_of-ccx.Ubuntu1604/referenceOutput/Inner-Fluid/precice-adapter-config.yml
@@ -7,3 +7,5 @@ interfaces:
       patches: [interface]
       read-data: [Sink-Temperature-Solid, Heat-Transfer-Coefficient-Solid]
       write-data: [Sink-Temperature-Inner-Fluid, Heat-Transfer-Coefficient-Inner-Fluid]
+
+CHTenabled: true

--- a/Test_of-ccx.Ubuntu1604/referenceOutput/Outer-Fluid/precice-adapter-config.yml
+++ b/Test_of-ccx.Ubuntu1604/referenceOutput/Outer-Fluid/precice-adapter-config.yml
@@ -7,3 +7,5 @@ interfaces:
       patches: [interface]
       read-data: [Sink-Temperature-Solid, Heat-Transfer-Coefficient-Solid]
       write-data: [Sink-Temperature-Outer-Fluid, Heat-Transfer-Coefficient-Outer-Fluid]
+
+CHTenabled: true

--- a/Test_of-of.Ubuntu1604/referenceOutput/Fluid/precice-adapter-config.yml
+++ b/Test_of-of.Ubuntu1604/referenceOutput/Fluid/precice-adapter-config.yml
@@ -4,7 +4,10 @@ precice-config-file: precice-config.xml
 
 interfaces:
 - mesh: Fluid-Mesh
+  #locations: faceCenters # optional, defaults to faceCenters
   patches:
   - interface
   write-data: Temperature
   read-data: Heat-Flux
+
+CHTenabled: true

--- a/Test_of-of.Ubuntu1604/referenceOutput/Solid/precice-adapter-config.yml
+++ b/Test_of-of.Ubuntu1604/referenceOutput/Solid/precice-adapter-config.yml
@@ -8,3 +8,5 @@ interfaces:
   - interface
   write-data: Heat-Flux
   read-data: Temperature
+
+CHTenabled: true


### PR DESCRIPTION
There were some changes to the YML configuration of the OpenFOAM adapter, described in this [pull request ](https://github.com/precice/openfoam-adapter/pull/56). Correspondingly tutorial files were [modified](https://github.com/precice/tutorials/blob/c5d5651ff837d4fd0c8cc598d72e4a866ecf7a83/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX/Inner-Fluid/precice-adapter-config.yml#L11)  as well. However reference files in the systemtests were not, so openfoam tests are [failing](https://travis-ci.org/precice/systemtests) now. 

This commit syncs the files. 
