### PR TITLE
Adjust ARPACK installation 

### DIFF
--- a/Test_of-ccx.Ubuntu1604/Dockerfile
+++ b/Test_of-ccx.Ubuntu1604/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get -qq update && apt-get -qq install \
     automake \
     autoconf \
     autotools-dev \
-    libarpack2-dev \
     libyaml-cpp-dev
 
 # Installing OpenFOAM 4.1

--- a/Test_su2-ccx.Ubuntu1604/Dockerfile
+++ b/Test_su2-ccx.Ubuntu1604/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -qq update && apt-get -qq install \
     automake \
     autoconf \
     autotools-dev \
-    libarpack2-dev \
     libyaml-cpp-dev    
 
 # Downloading CalculiX 2.13

--- a/Test_su2-ccx.Ubuntu1604/Makefile_su2-ccx
+++ b/Test_su2-ccx.Ubuntu1604/Makefile_su2-ccx
@@ -1,7 +1,7 @@
 # Specify the locations of: the original CCX source, SPOOLES and ARPACK
 CCX			= /CalculiX/ccx_2.13/src
 SPOOLES			= /spooles.2.2
-ARPACK			= /usr/lib
+ARPACK			= /usr/local/ARPACK
 PRECICE_ROOT		= /precice
 
 # Specify where to store the generated .o files
@@ -18,7 +18,7 @@ INCLUDES = \
 
 LIBS = \
 	$(SPOOLES)/spooles.a \
-	$(ARPACK)/libarpack.a \
+	$(ARPACK)/libarpack_INTEL.a \
     	-lm -lc -lpthread -llapack -lblas \
     	-L$(PRECICE_ROOT)/build/last \
     	-lprecice \


### PR DESCRIPTION
Although both `Test_su2-ccx.Ubuntu1604/Makefile_su2-ccx` and `Test_of-ccx.Ubuntu1604/Makefile_of_ccx` use and their corresponding  Dockerfiles install ARPACK, they do it it differently for some reason, although there is no need for it: 

* Both Dockerfiles specify to install  Ubuntu package `libarpack2-dev` and then *also* manually download and install ARPACK to `/usr/local `
* Then then use different versions, 

https://github.com/precice/systemtests/blob/35c4651c52aaa3229f36ce0d8f52336325ca2cad/Test_su2-ccx.Ubuntu1604/Makefile_su2-ccx#L4
https://github.com/precice/systemtests/blob/35c4651c52aaa3229f36ce0d8f52336325ca2cad/Test_of-ccx.Ubuntu1604/Makefile_of_ccx#L4

Using system package will break things in 18.04 ( as I already tested ) and in general differences above are not needed and confusing. I removed system install and now ARPACK is built from source in both systemtests. I [tested](https://travis-ci.org/shkodm/systemtests/builds/478563406) on my branch and this does not break anything. 