### PR TITLE
Fix C/CPP Include ENV not set

### DIFF
--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -49,3 +49,5 @@ RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc)
 ENV PRECICE_ROOT="/precice"
 ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}"
 ENV LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}"
+ENV CPLUS_INCLUDE_PATH="$PRECICE_ROOT/src:${CPLUS_INCLUDE_PATH}"
+ENV C_INCLUDE_PATH="$PRECICE_ROOT/src:${C_INCLUDE_PATH}"

--- a/Dockerfile.Ubuntu1804
+++ b/Dockerfile.Ubuntu1804
@@ -43,3 +43,5 @@ RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc)
 ENV PRECICE_ROOT="/precice"
 ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}"
 ENV LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}"
+ENV CPLUS_INCLUDE_PATH="$PRECICE_ROOT/src:${CPLUS_INCLUDE_PATH}"
+ENV C_INCLUDE_PATH="$PRECICE_ROOT/src:${C_INCLUDE_PATH}"


### PR DESCRIPTION
This _should_ fix the currently failing build of the python bindings.