### PR TITLE
Shrink the image size and reduce layers

### DIFF
--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -46,7 +46,8 @@ WORKDIR precice
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
-RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc)
+RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc) && \
+    find . -type f \( -name "*.o" -or -name "*.os" \) -exec rm {} +
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/precice"

--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -18,10 +18,12 @@ RUN apt-get -qq update && apt-get -qq install \
     rm -rf /var/lib/apt/lists/*
 
 # Installing boost from source
+WORKDIR /boost-build
 RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2' -O - | tar xj && \
     cd boost_1_65_1 && \
     ./bootstrap.sh --with-libraries=log,thread,system,filesystem,program_options,test --prefix=/usr/local && \
     ./b2 -j$(nproc) install && \
+    rm -rf /boost-build && \
     ldconfig
 
 # Rebuild image if force_rebuild after that command

--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -30,10 +30,10 @@ RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1
 ARG CACHEBUST
 
 # Setting some environment variables for installing preCICE
-ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3"
-ENV CPATH="/usr/include/eigen3:${CPATH}"
-ENV PETSC_DIR="/usr/lib/petscdir/3.6.2/"
-ENV PETSC_ARCH="x86_64-linux-gnu-real"
+ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
+    CPATH="/usr/include/eigen3:${CPATH}" \
+    PETSC_DIR="/usr/lib/petscdir/3.6.2/" \
+    PETSC_ARCH="x86_64-linux-gnu-real"
 
 # Building preCICE
 ARG branch=develop
@@ -50,6 +50,8 @@ RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc) && \
     find . -type f \( -name "*.o" -or -name "*.os" \) -exec rm {} +
 
 # Setting preCICE environment variables
-ENV PRECICE_ROOT="/precice"
-ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}"
-ENV LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}"
+ENV PRECICE_ROOT="/precice" \
+ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}" \
+    CPATH="$PRECICE_ROOT/src:${CPATH}" \
+    CPLUS_INCLUDE_PATH="$PRECICE_ROOT/src:${CPLUS_INCLUDE_PATH}"

--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -14,7 +14,8 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
-    bzip2
+    bzip2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Installing boost from source
 RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2' -O - | tar xj && \

--- a/Dockerfile.Ubuntu1604
+++ b/Dockerfile.Ubuntu1604
@@ -37,8 +37,8 @@ ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
 
 # Building preCICE
 ARG branch=develop
-RUN git clone --branch $branch https://github.com/precice/precice.git
-WORKDIR precice
+RUN git clone --branch $branch https://github.com/precice/precice.git /precice
+WORKDIR /precice
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in

--- a/Dockerfile.Ubuntu1804
+++ b/Dockerfile.Ubuntu1804
@@ -38,7 +38,8 @@ WORKDIR precice
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
-RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc)
+RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc) && \
+    find . -type f \( -name "*.o" -or -name "*.os" \) -exec rm {} +
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/precice"

--- a/Dockerfile.Ubuntu1804
+++ b/Dockerfile.Ubuntu1804
@@ -22,10 +22,10 @@ RUN apt-get -qq update && apt-get -qq install \
 ARG CACHEBUST
 
 # Setting some environment variables for installing preCICE
-ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3"
-ENV CPATH="/usr/include/eigen3:${CPATH}"
-ENV PETSC_DIR="/usr/lib/petscdir/3.6.2/"
-ENV PETSC_ARCH="x86_64-linux-gnu-real"
+ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
+    CPATH="/usr/include/eigen3:${CPATH}" \
+    PETSC_DIR="/usr/lib/petscdir/3.6.2/" \
+    PETSC_ARCH="x86_64-linux-gnu-real"
 
 # Building preCICE
 ARG branch=develop
@@ -42,6 +42,8 @@ RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc) && \
     find . -type f \( -name "*.o" -or -name "*.os" \) -exec rm {} +
 
 # Setting preCICE environment variables
-ENV PRECICE_ROOT="/precice"
-ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}"
-ENV LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}"
+ENV PRECICE_ROOT="/precice" \
+ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}" \
+    LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}" \
+    CPATH="$PRECICE_ROOT/src:${CPATH}" \
+    CPLUS_INCLUDE_PATH="$PRECICE_ROOT/src:${CPLUS_INCLUDE_PATH}"

--- a/Dockerfile.Ubuntu1804
+++ b/Dockerfile.Ubuntu1804
@@ -29,8 +29,8 @@ ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
 
 # Building preCICE
 ARG branch=develop
-RUN git clone --branch $branch https://github.com/precice/precice.git
-WORKDIR precice
+RUN git clone --branch $branch https://github.com/precice/precice.git /precice
+WORKDIR /precice
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in

--- a/Dockerfile.Ubuntu1804
+++ b/Dockerfile.Ubuntu1804
@@ -15,7 +15,8 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
-    bzip2    
+    bzip2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST

--- a/Test_bindings.Ubuntu1804/Dockerfile
+++ b/Test_bindings.Ubuntu1804/Dockerfile
@@ -34,7 +34,7 @@ RUN scons
 
 # Builds the C++ solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/cpp
-RUN mpic++ -std=c++11 -I$PRECICE_ROOT/src main.cpp -lprecice
+RUN mpic++ -std=c++11 main.cpp -lprecice
 
 # Builds the Fortran solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/fortran

--- a/Test_bindings.Ubuntu1804/Dockerfile
+++ b/Test_bindings.Ubuntu1804/Dockerfile
@@ -9,7 +9,8 @@ ENV USER=root
 
 # Installing necessary dependecies
 RUN apt-get -qq update && apt-get -qq install \
-    cython python-numpy python-enum34 python-mpi4py cython3 python3-numpy python3-mpi4py
+    cython python-numpy python-enum34 python-mpi4py cython3 python3-numpy python3-mpi4py && \
+    rm -rf /var/lib/apt/lists/*
     
 # Builds the precice python binding for python2
 WORKDIR $PRECICE_ROOT/src/precice/bindings/python

--- a/Test_bindings/Dockerfile
+++ b/Test_bindings/Dockerfile
@@ -40,7 +40,7 @@ RUN scons
 
 # Builds the C++ solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/cpp
-RUN mpic++ -std=c++11 -I$PRECICE_ROOT/src main.cpp -lprecice
+RUN mpic++ -std=c++11 main.cpp -lprecice
 
 # Builds the Fortran solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/fortran

--- a/Test_bindings/Dockerfile
+++ b/Test_bindings/Dockerfile
@@ -9,7 +9,8 @@ ENV USER=root
 
 # Installing necessary dependecies
 RUN apt-get -qq update && apt-get -qq install \
-    python-pip python-enum34 python3-pip
+    python-pip python-enum34 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
     
 # Installing necessary python dependecies; we have to use pip, since cython provided by apt-get is too old.
 RUN pip2 install --upgrade pip

--- a/Test_bindings/Dockerfile
+++ b/Test_bindings/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get -qq update && apt-get -qq install \
     rm -rf /var/lib/apt/lists/*
     
 # Installing necessary python dependecies; we have to use pip, since cython provided by apt-get is too old.
-RUN pip2 install --upgrade pip
-RUN pip2 install Cython mpi4py
-RUN pip3 install --upgrade pip
-RUN pip3 install Cython mpi4py numpy
+RUN pip2 install --upgrade pip && \
+    pip2 install Cython mpi4py && \
+    pip3 install --upgrade pip && \
+    pip3 install Cython mpi4py numpy
 
 # Builds the precice python binding for python2
 WORKDIR $PRECICE_ROOT/src/precice/bindings/python

--- a/Test_compile-and-test/Dockerfile
+++ b/Test_compile-and-test/Dockerfile
@@ -7,7 +7,8 @@ FROM $from
 USER root
 ENV USER=root
 
-RUN apt-get -qq update && apt-get -qq install python3
+RUN apt-get -qq update && apt-get -qq install python3 && \
+    rm -rf /var/lib/apt/lists/*
 
 # create a new non-root user that has access to $PRECICE_ROOT
 RUN adduser testuser

--- a/Test_of-ccx.Ubuntu1604/Dockerfile
+++ b/Test_of-ccx.Ubuntu1604/Dockerfile
@@ -16,13 +16,15 @@ RUN apt-get -qq update && apt-get -qq install \
     automake \
     autoconf \
     autotools-dev \
-    libyaml-cpp-dev
+    libyaml-cpp-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Installing OpenFOAM 4.1
 RUN add-apt-repository "http://dl.openfoam.org/ubuntu dev" && \
     sh -c "curl -s http://dl.openfoam.org/gpg.key | apt-key add -" && \
     add-apt-repository http://dl.openfoam.org/ubuntu && apt update && \
-    apt-get -qq --no-install-recommends install openfoam4
+    apt-get -qq --no-install-recommends install openfoam4 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Downloading Calculix 2.15
 WORKDIR /

--- a/Test_of-of.Ubuntu1604/Dockerfile
+++ b/Test_of-of.Ubuntu1604/Dockerfile
@@ -11,13 +11,15 @@ ENV USER=root
 RUN apt-get -qq update && apt-get -qq install \
     software-properties-common \
     wget apt-transport-https \
-    libyaml-cpp-dev
+    libyaml-cpp-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Installing OpenFOAM 4.1
 RUN add-apt-repository "http://dl.openfoam.org/ubuntu dev"
 RUN sh -c "wget -O - http://dl.openfoam.org/gpg.key | apt-key add -"
 RUN add-apt-repository http://dl.openfoam.org/ubuntu && apt update
-RUN apt-get -y install openfoam4 --no-install-recommends
+RUN apt-get -y install openfoam4 --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
 
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST

--- a/Test_su2-ccx.Ubuntu1604/Dockerfile
+++ b/Test_su2-ccx.Ubuntu1604/Dockerfile
@@ -61,11 +61,11 @@ WORKDIR /
 RUN git clone --branch v6.0.0 https://github.com/su2code/SU2.git su2-source
 RUN git clone https://github.com/precice/su2-adapter.git
 
-ENV SU2_HOME="/su2-source"
-ENV SU2_BIN="/su2-bin"
-ENV SU2_RUN="/su2-bin/bin"
-ENV PATH="/su2-bin/bin:${PATH}"
-ENV PYTHONPATH="/su2-bin/bin:${PYTHONPATH}"
+ENV SU2_HOME="/su2-source" \
+    SU2_BIN="/su2-bin" \
+    SU2_RUN="/su2-bin/bin" \
+    PATH="/su2-bin/bin:${PATH}" \
+    PYTHONPATH="/su2-bin/bin:${PYTHONPATH}"
 
 # Installing su2-adapter
 WORKDIR /su2-adapter

--- a/Test_su2-ccx.Ubuntu1604/Dockerfile
+++ b/Test_su2-ccx.Ubuntu1604/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get -qq update && apt-get -qq install \
     automake \
     autoconf \
     autotools-dev \
-    libyaml-cpp-dev    
+    libyaml-cpp-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Downloading CalculiX 2.15
 WORKDIR /


### PR DESCRIPTION
This PR reduces the docker image size and layer counts. It will:
* add clean-up after apt-get
* removes the boost build directory after install in Ubuntu 16.04
* removes `.o`and `.os` files after building precice with `scons`
* merges `ENV` calls
* merges pip calls
* adds  `CPATH` and `CPLUS_INCLUDE_PATH` to include precice turning `-I` in solverdummies obsolete
* makes the precice path explicit in clone.

reviewers: last review please merge if ok.