### PR TITLE
WIP Add PIP install for the bindings

### DIFF
--- a/Test_bindings.Ubuntu1804/Dockerfile
+++ b/Test_bindings.Ubuntu1804/Dockerfile
@@ -8,16 +8,15 @@ USER root
 ENV USER=root
 
 # Installing necessary dependecies
-RUN apt-get -qq update && apt-get -qq install \
-    cython python-numpy python-enum34 python-mpi4py cython3 python3-numpy python3-mpi4py
+RUN apt-get -qq update && apt-get -qq install python2-pip python3-pip && \
+    pip2 install --user Cython numpy enum34 mpi4py && \
+    pip3 install --user Cython numpy enum34 mpi4py
     
 # Builds the precice python binding for python2
-WORKDIR $PRECICE_ROOT/src/precice/bindings/python
-RUN python2 setup.py install
+RUN pip2 install --user -e $PRECICE_ROOT/src/precice/bindings/python
 
 # Builds the precice python binding for python3
-WORKDIR $PRECICE_ROOT/src/precice/bindings/python
-RUN python3 setup.py install
+RUN pip3 install --user -e $PRECICE_ROOT/src/precice/bindings/python
 
 # Runs the python solverdummy with python2
 WORKDIR $PRECICE_ROOT/tools/solverdummies/python

--- a/Test_bindings/Dockerfile
+++ b/Test_bindings/Dockerfile
@@ -8,22 +8,17 @@ USER root
 ENV USER=root
 
 # Installing necessary dependecies
-RUN apt-get -qq update && apt-get -qq install \
-    python-pip python-enum34 python3-pip
-    
-# Installing necessary python dependecies; we have to use pip, since cython provided by apt-get is too old.
-RUN pip2 install --upgrade pip
-RUN pip2 install Cython mpi4py
-RUN pip3 install --upgrade pip
-RUN pip3 install Cython mpi4py numpy
+RUN apt-get -qq update && apt-get -qq install python2-pip python3-pip && \
+    pip2 install --upgrade pip && \
+    pip3 install --upgrade pip && \
+    pip2 install --user cython numpy enum34 mpi4py && \
+    pip3 install --user cython numpy enum34 mpi4py
 
 # Builds the precice python binding for python2
-WORKDIR $PRECICE_ROOT/src/precice/bindings/python
-RUN python2 setup.py install
+RUN pip2 install --user -e $PRECICE_ROOT/src/precice/bindings/python
 
 # Builds the precice python binding for python3
-WORKDIR $PRECICE_ROOT/src/precice/bindings/python
-RUN python3 setup.py install
+RUN pip3 install --user -e $PRECICE_ROOT/src/precice/bindings/python
 
 # Runs the python solverdummy with python2
 WORKDIR $PRECICE_ROOT/tools/solverdummies/python


### PR DESCRIPTION
This PR:
* installs only `python[2|3]-pip` via `apt-get`.
* installs all the dependencies via `pip` into the user (which will work for actual users)
* installs the precice bindings directly via `pip`

The second point should become obsolete, once we add correct dependencies to the precice package.

This pr depends on #39 for the env changes
reviewers: please comment /  approve only