### PR TITLE
use sudo command instead of root user

### DIFF
--- a/Dockerfile.Ubuntu1604.package
+++ b/Dockerfile.Ubuntu1604.package
@@ -34,8 +34,10 @@ RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
-# create user precice
-RUN useradd -ms /bin/bash precice && adduser precice sudo
+# create user precice and add precice to sudo group. User precice can execute sudo without entering the password.
+RUN useradd -ms /bin/bash precice && \ 
+    adduser precice sudo && \
+    echo 'precice ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 USER precice
 WORKDIR /home/precice
 

--- a/Dockerfile.Ubuntu1604.package
+++ b/Dockerfile.Ubuntu1604.package
@@ -5,6 +5,7 @@ FROM ubuntu:16.04
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
+    sudo \
     build-essential \
     libeigen3-dev \
     libxml2-dev \
@@ -34,7 +35,7 @@ RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1
 ARG CACHEBUST
 
 # create user precice
-RUN useradd -ms /bin/bash precice
+RUN useradd -ms /bin/bash precice && adduser precice sudo
 USER precice
 WORKDIR /home/precice
 
@@ -69,10 +70,8 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
-    mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
-    rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
-USER root
-RUN cd /home/precice && dpkg -i --ignore-depends=libboost-dev,libboost-log-dev,libboost-thread-dev,libboost-system-dev,libboost-filesystem-dev,libboost-program-options-dev,libboost-test-dev $(find . -maxdepth 1 -name "*.deb")
+    sudo dpkg -i --ignore-depends=libboost-dev,libboost-log-dev,libboost-thread-dev,libboost-system-dev,libboost-filesystem-dev,libboost-program-options-dev,libboost-test-dev $(find . -maxdepth 1 -name "*.deb") && \
+    rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 USER precice

--- a/Dockerfile.Ubuntu1604.sudo
+++ b/Dockerfile.Ubuntu1604.sudo
@@ -34,8 +34,10 @@ RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
-# create user precice
-RUN useradd -ms /bin/bash precice && adduser precice sudo
+# create user precice and add precice to sudo group. User precice can execute sudo without entering the password.
+RUN useradd -ms /bin/bash precice && \ 
+    adduser precice sudo && \
+    echo 'precice ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 USER precice
 WORKDIR /home/precice
 

--- a/Dockerfile.Ubuntu1604.sudo
+++ b/Dockerfile.Ubuntu1604.sudo
@@ -5,6 +5,7 @@ FROM ubuntu:16.04
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
+    sudo \
     build-essential \
     libeigen3-dev \
     libxml2-dev \
@@ -34,7 +35,7 @@ RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1
 ARG CACHEBUST
 
 # create user precice
-RUN useradd -ms /bin/bash precice
+RUN useradd -ms /bin/bash precice && adduser precice sudo
 USER precice
 WORKDIR /home/precice
 
@@ -65,14 +66,10 @@ RUN mkdir /home/precice/precice-build && \
           -DPYTHON=$python_para \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test_base
-# user with sudo rights is needed to install preCICE in system directory
-USER root
-RUN cd /home/precice/precice-build && \
-    make install && \
-    ldconfig
-USER precice
-RUN rm -r /home/precice/precice-build
+    make test_base && \
+    sudo make install && \
+    sudo ldconfig && \
+    rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1804.package
+++ b/Dockerfile.Ubuntu1804.package
@@ -58,7 +58,8 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
-    sudo dpkg -i $(find . -maxdepth 1 -name "*.deb")
+    sudo dpkg -i $(find . -maxdepth 1 -name "*.deb") && \
+    rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice"

--- a/Dockerfile.Ubuntu1804.package
+++ b/Dockerfile.Ubuntu1804.package
@@ -22,8 +22,10 @@ RUN apt-get -qq update && apt-get -qq install \
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
-# create user precice
-RUN useradd -ms /bin/bash precice && adduser precice sudo
+# create user precice and add precice to sudo group. User precice can execute sudo without entering the password.
+RUN useradd -ms /bin/bash precice && \ 
+    adduser precice sudo && \
+    echo 'precice ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 USER precice
 WORKDIR /home/precice
 

--- a/Dockerfile.Ubuntu1804.package
+++ b/Dockerfile.Ubuntu1804.package
@@ -5,6 +5,7 @@ FROM ubuntu:18.04
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
+    sudo \
     build-essential \
     libboost-all-dev \
     libeigen3-dev \
@@ -22,7 +23,7 @@ RUN apt-get -qq update && apt-get -qq install \
 ARG CACHEBUST
 
 # create user precice
-RUN useradd -ms /bin/bash precice
+RUN useradd -ms /bin/bash precice && adduser precice sudo
 USER precice
 WORKDIR /home/precice
 
@@ -57,12 +58,7 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
-    mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
-    rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
-# user with sudo rights is needed to install preCICE in debian package
-USER root
-RUN cd /home/precice && dpkg -i $(find . -maxdepth 1 -name "*.deb")
+    sudo dpkg -i $(find . -maxdepth 1 -name "*.deb")
 
 # Setting preCICE environment variables
-USER precice
 ENV PRECICE_ROOT="/home/precice/precice"

--- a/Dockerfile.Ubuntu1804.sudo
+++ b/Dockerfile.Ubuntu1804.sudo
@@ -5,6 +5,7 @@ FROM ubuntu:18.04
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
+    sudo \
     build-essential \
     libboost-all-dev \
     libeigen3-dev \
@@ -22,7 +23,7 @@ RUN apt-get -qq update && apt-get -qq install \
 ARG CACHEBUST
 
 # create user precice
-RUN useradd -ms /bin/bash precice
+RUN useradd -ms /bin/bash precice && adduser precice sudo
 USER precice
 WORKDIR /home/precice
 
@@ -53,14 +54,10 @@ RUN mkdir /home/precice/precice-build && \
           -DPYTHON=$python_para \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test_base
-# user with sudo rights is needed to install preCICE in system directory
-USER root
-RUN cd /home/precice/precice-build && \
-    make install && \
-    ldconfig
-USER precice
-RUN rm -r /home/precice/precice-build
+    make test_base && \
+    sudo make install && \
+    sudo ldconfig && \
+    rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1804.sudo
+++ b/Dockerfile.Ubuntu1804.sudo
@@ -22,8 +22,10 @@ RUN apt-get -qq update && apt-get -qq install \
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
-# create user precice
-RUN useradd -ms /bin/bash precice && adduser precice sudo
+# create user precice and add precice to sudo group. User precice can execute sudo without entering the password.
+RUN useradd -ms /bin/bash precice && \ 
+    adduser precice sudo && \
+    echo 'precice ALL=(ALL) NOPASSWD: ALL' | sudo EDITOR='tee -a' visudo
 USER precice
 WORKDIR /home/precice
 


### PR DESCRIPTION
Switching between users `root` and `precice` for executing commands that need `sudo` privileges (e.g. `dpkg` or `apt-get install`) is replaced by the user `precice` using the `sudo` command. This also reduces layer size.

If we want to be able to use the `sudo` command inside docker, this requires the following changes:

* `sudo` has to be installed via `apt-get`
* the sudoers file has to be modified, such that `precice` can call `sudo` without having to enter a password.