### PR TITLE
Add architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Design and Implementation of system tests for the distributed multi-physics simu
 # Status
 [![Build Status](https://travis-ci.org/precice/systemtests.svg?branch=master)](https://travis-ci.org/precice/systemtests)
 
+# General Information
+
+* [Architecture](doc/architecture.md)
+
 # Setup and running
 
 ## Dependencies

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -87,6 +87,16 @@ Base images will be matched against Tests in the following way:
         * drop a feature and repeat matching
       * else run Test with matching `TestClass` without `SystemSpec`
 
+Examples:
+
+Base Image                        | Matching Tests
+---                               | ---
+`Dockerfile.Ubuntu1804`           | `Test_of-of.Ubuntu1804`, _(no matching su2)_
+`Dockerfile.Ubuntu.1804.Boost160` | `Test_of-of.Ubuntu1804.Boost160`
+`Dockerfile.Ubuntu.1804.NoPETSc`  | `Test_of-of.Ubuntu1804`
+`Dockerfile.Ubuntu1604`           | `Test_of-of`, `Test_su2.Ubuntu1604`
+`Dockerfile.Ubuntu1604.Boost160`  | `Test_of-of`, `Test_su2.Ubuntu1604`
+
 ### Restrictions:
 * Run commands as user `precice`
 * Use `pip install --user` to install python dependencies

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,96 @@
+# Architecture
+
+The architecture of the system tests consist out of two layers.
+The interface between the layers are docker images.
+
+## Grammar
+
+```
+// terminals
+System         = string
+TestClass      = string
+Feature        = string
+Dockerfile     = "Dockerfile"
+TestPrefix     = "Test"
+.              = "."
+_              = "_"
+
+// Non-terminals
+SystemSpec     = System [. Feature]*
+Base           = Dockerfile . SystemSpec
+TestSpec       = TestClass | TestClass SystemSpec
+Test           = TestPrefix _ TestSpec
+```
+
+## Base Images
+
+### Naming Convention: 
+Described by Grammar: `Base`
+
+Examples:
+```
+Dockerfile.Ubuntu1804
+Dockerfile.Ubuntu1804.Boost160
+Dockerfile.Ubuntu1804.NoPETSc
+Dockerfile.Ubuntu1604
+Dockerfile.Ubuntu1604.Boost160
+```
+
+### Responsibilities:
+The image needs to provide:
+1) Software:
+    1) `cmake`
+    2) `make`
+    3) `git`
+    4) a C++ compiler
+    5) MPI binaries
+    6) `python3`
+    7) `python3-dev`
+    8) `pip`
+2) all dependencies necessary to build and use preCICE
+3) a user `precice` with a home directory containing:
+    * `src` a checkout of the git repository
+5) a discoverable install of preCICE:
+    * `pgk-config --exist precice` returns true
+    * `#include <precice/SolverInterface.hpp` has to work either out-of-the-box or by passing the flag `-I` using pkg-config.
+    * `ld -lprecice` has to work either out-of-the-box or by passing the flag `-L` using pkg-config.
+    * `binprecice` and `testprecice` have to be in `PATH`
+    * `PRECICE_ROOT` hast to be set so that at least `runprecice` will be able to run the tests.
+
+_Optional: after building preCICE, the "base" test-set has to be executed with `make test_base`!_
+
+## Tests
+
+### Naming Convention: 
+Described by Grammar: `Base`
+
+Examples:
+```
+Test_of-of
+Test_of-of.Ubuntu1804
+Test_of-of.Ubuntu1804.Boost160
+Test_su2.Ubuntu1604
+```
+
+### Matching Logic:
+
+Base images will be matched against Tests in the following way:
+* For each `Base` image:
+  * For each `TestClass`:
+    * For each `Test` with matching `TestClass` and existing `SystemSpec`:
+      * if `Test` and `Base` have matching `SystemSpec`
+        * run the test
+      * else if `Base` `SystemSpec` has `Features`:
+        * drop a feature and repeat matching
+      * else run Test with matching `TestClass` without `SystemSpec`
+
+### Restrictions:
+* Run commands as user `precice`
+* Use `pip install --user` to install python dependencies
+* Avoid using `apt-get` or other system specify package managers
+* Do not use system specify package manager in a `Test` without `SystemSpec`
+
+### Responsibilities:
+
+* A failing `RUN` marks the test as failed.
+* Do not fail silently!

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -18,7 +18,7 @@ _              = "_"
 // Non-terminals
 SystemSpec     = System [. Feature]*
 Base           = Dockerfile . SystemSpec
-TestSpec       = TestClass | TestClass SystemSpec
+TestSpec       = TestClass | TestClass . SystemSpec
 Test           = TestPrefix _ TestSpec
 ```
 
@@ -37,7 +37,7 @@ Dockerfile.Ubuntu1604.Boost160
 ```
 
 ### Responsibilities:
-The image needs to provide:
+The image must provide:
 1) Software:
     1) `cmake`
     2) `make`
@@ -54,15 +54,15 @@ The image needs to provide:
     * `pgk-config --exist precice` returns true
     * `#include <precice/SolverInterface.hpp` has to work either out-of-the-box or by passing the flag `-I` using pkg-config.
     * `ld -lprecice` has to work either out-of-the-box or by passing the flag `-L` using pkg-config.
-    * `binprecice` and `testprecice` have to be in `PATH`
-    * `PRECICE_ROOT` hast to be set so that at least `runprecice` will be able to run the tests.
+    * `binprecice` and `testprecice` have to be in `$PATH`
+    * `$PRECICE_ROOT` hast to be set so that at least `testprecice` will be able to run the tests.
 
 _Optional: after building preCICE, the "base" test-set has to be executed with `make test_base`!_
 
 ## Tests
 
 ### Naming Convention: 
-Described by Grammar: `Base`
+Described by Grammar: `Test`
 
 Examples:
 ```
@@ -92,5 +92,5 @@ Base images will be matched against Tests in the following way:
 
 ### Responsibilities:
 
-* A failing `RUN` marks the test as failed.
+* To signal a failing systemtest, make the corresponding `RUN` command fail.
 * Do not fail silently!

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,9 @@
 # Architecture
 
-The architecture of the system tests consist out of two layers.
+The architecture of the system tests consist out of two layers:
+1) [The Base Images](#base-images) each containing a system with installed dependencies and a discoverable preCICE installation.
+2) [The Tests](#tests) each containing a system test to run.
+
 The interface between the layers are docker images.
 
 ## Grammar

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The architecture of the system tests consist out of two layers:
+The architecture of the system tests consists out of two layers:
 1) [The Base Images](#base-images) each containing a system with installed dependencies and a discoverable preCICE installation.
 2) [The Tests](#tests) each containing a system test to run.
 


### PR DESCRIPTION
This PR adds an overview of the system-tests architecture.
It aims to be more visible than an issue and more detailed in terms of responsibilities and restrictions.

The architecture doc includes:
* Layers
* Naming Scheme with Grammar
* Responsibilities
* Restrictions

This is based on the issue #14.
@BenjaminRueth @floli Please give feedback on the correctness of this doc.