### PR TITLE
Use ccache during building of precice images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 *
+!post_install_hook.sh
+!pre_install_hook.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
   - docker
 cache:
   directories:
-    - $HOME/ccache
+    - $HOME/cache
 jobs:
   include:
 
@@ -26,7 +26,7 @@ jobs:
     if: fork = false
     name: "Ubuntu 16.04 home"
     script:
-    - source setup_ccache_sync.sh ubuntu1604
+    - source setup_docker_ci_cache.sh ubuntu1604
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.home -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -38,7 +38,7 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.sudo"
     script:
-    - source setup_ccache_sync.sh ubuntu1604
+    - source setup_docker_ci_cache.sh ubuntu1604
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.sudo -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -50,7 +50,7 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.package"
     script:
-    - source setup_ccache_sync.sh ubuntu1604
+    - source setup_docker_ci_cache.sh ubuntu1604
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.package -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -62,7 +62,7 @@ jobs:
     name: "Ubuntu 18.04.home"
     if: type = cron
     script:
-    - source setup_ccache_sync.sh ubuntu1804
+    - source setup_docker_ci_cache.sh ubuntu1804
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.home -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -74,7 +74,7 @@ jobs:
     name: "Ubuntu 18.04.sudo"
     if: type = cron
     script:
-    - source setup_ccache_sync.sh ubuntu1804
+    - source setup_docker_ci_cache.sh ubuntu1804
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.sudo -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -86,7 +86,7 @@ jobs:
     name: "Ubuntu 18.04.package"
     if: fork = false
     script:
-    - source setup_ccache_sync.sh ubuntu1804
+    - source setup_docker_ci_cache.sh ubuntu1804
     - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.package -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ python:
   - "3.5"
 services:
   - docker
+cache:
+  directories:
+    - $HOME/ccache
 jobs:
   include:
+
   - stage: Building preCICE
     if: fork = false
     name: "Arch Linux"
@@ -22,7 +26,8 @@ jobs:
     if: fork = false
     name: "Ubuntu 16.04 home"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.home -t precice .
+    - source setup_ccache_sync.sh ubuntu1604
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.home -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
@@ -33,7 +38,8 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.sudo"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.sudo -t precice .
+    - source setup_ccache_sync.sh ubuntu1604
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.sudo -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
@@ -44,7 +50,8 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.package"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.package -t precice .
+    - source setup_ccache_sync.sh ubuntu1604
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1604.package -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
@@ -55,7 +62,8 @@ jobs:
     name: "Ubuntu 18.04.home"
     if: type = cron
     script:
-    - docker build -f Dockerfile.Ubuntu1804.home -t precice .
+    - source setup_ccache_sync.sh ubuntu1804
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.home -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
@@ -66,7 +74,8 @@ jobs:
     name: "Ubuntu 18.04.sudo"
     if: type = cron
     script:
-    - docker build -f Dockerfile.Ubuntu1804.sudo -t precice .
+    - source setup_ccache_sync.sh ubuntu1804
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.sudo -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images
@@ -77,7 +86,8 @@ jobs:
     name: "Ubuntu 18.04.package"
     if: fork = false
     script:
-    - docker build -f Dockerfile.Ubuntu1804.package -t precice .
+    - source setup_ccache_sync.sh ubuntu1804
+    - docker build --build-arg CCACHE_REMOTE=$CCACHE_REMOTE -f Dockerfile.Ubuntu1804.package -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker images

--- a/Dockerfile.Ubuntu1604.home
+++ b/Dockerfile.Ubuntu1604.home
@@ -2,6 +2,7 @@
 
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
+ARG CCACHE_REMOTE
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -13,7 +14,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
-    bzip2 && \
+    bzip2 \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Installing cmake
@@ -52,6 +55,10 @@ WORKDIR /home/precice/precice
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -65,10 +72,15 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
     make install && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi && \
     rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables

--- a/Dockerfile.Ubuntu1604.home
+++ b/Dockerfile.Ubuntu1604.home
@@ -3,6 +3,7 @@
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
 ARG CCACHE_REMOTE
+ENV CCACHE_REMOTE=${CCACHE_REMOTE}
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -23,6 +24,8 @@ RUN apt-get -qq update && apt-get -qq install \
 WORKDIR /cmake
 RUN wget -q -O- 'https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz' | tar xz
 ENV PATH="/cmake/cmake-3.13.4-Linux-x86_64/bin:$PATH"
+
+COPY pre_install_hook.sh post_install_hook.sh /home/
 
 # Installing boost from source
 WORKDIR /boost-build
@@ -55,15 +58,13 @@ WORKDIR /home/precice/precice
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE and clean-up generated object files
 RUN mkdir /home/precice/precice-build && \
+    bash /home/pre_install_hook.sh --dep=precice --ccache && \
     cd /home/precice/precice-build && \
     mkdir /home/precice/precice-install && \
     cmake -DBUILD_SHARED_LIBS=ON \
@@ -77,11 +78,8 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make install && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi && \
-    rm -r /home/precice/precice-build
+    bash /home/post_install_hook.sh --dep=precice --ccache && \
+    rm -rf /home/precice/precice-build ~/.ccache
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1604.package
+++ b/Dockerfile.Ubuntu1604.package
@@ -2,6 +2,7 @@
 
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
+ARG CCACHE_REMOTE
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -13,7 +14,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
-    bzip2 && \
+    bzip2 \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Installing cmake
@@ -51,6 +54,10 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -65,10 +72,15 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \ 
     make -j$(nproc) && \
     make test_base && \
     make package && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi && \
     mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
     rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
 USER root

--- a/Dockerfile.Ubuntu1604.package
+++ b/Dockerfile.Ubuntu1604.package
@@ -3,6 +3,7 @@
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
 ARG CCACHE_REMOTE
+ENV CCACHE_REMOTE=${CCACHE_REMOTE}
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -24,6 +25,7 @@ WORKDIR /cmake
 RUN wget -q -O- 'https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz' | tar xz
 ENV PATH="/cmake/cmake-3.13.4-Linux-x86_64/bin:$PATH"
 
+COPY pre_install_hook.sh post_install_hook.sh /home/
 # Installing boost from source
 WORKDIR /boost-build
 RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2' -O - | tar xj && \
@@ -54,15 +56,13 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE and clean-up generated object files
 RUN mkdir /home/precice/precice-build && \
+    bash /home/pre_install_hook.sh --dep=precice --ccache && \
     cd /home/precice/precice-build && \
     cmake -DBUILD_SHARED_LIBS=ON \
           -DPRECICE_Packages=ON \
@@ -73,16 +73,13 @@ RUN mkdir /home/precice/precice-build && \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          /home/precice/precice && \ 
+          /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi && \
+    bash /home/post_install_hook.sh --dep=precice --ccache && \
     mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
-    rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
+    rm -rf /home/precice/precice-build  ~/.ccache # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
 USER root
 RUN cd /home/precice && dpkg -i --ignore-depends=libboost-dev,libboost-log-dev,libboost-thread-dev,libboost-system-dev,libboost-filesystem-dev,libboost-program-options-dev,libboost-test-dev $(find . -maxdepth 1 -name "*.deb")
 

--- a/Dockerfile.Ubuntu1604.sudo
+++ b/Dockerfile.Ubuntu1604.sudo
@@ -2,6 +2,7 @@
 
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
+ARG CCACHE_REMOTE
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -13,7 +14,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
-    bzip2 && \
+    bzip2 \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Installing cmake
@@ -51,6 +54,10 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -63,9 +70,14 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test_base
+    make test_base && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \

--- a/Dockerfile.Ubuntu1604.sudo
+++ b/Dockerfile.Ubuntu1604.sudo
@@ -3,6 +3,7 @@
 # Using ubuntu 16.04 as basis
 FROM ubuntu:16.04
 ARG CCACHE_REMOTE
+ENV CCACHE_REMOTE=${CCACHE_REMOTE}
 
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
@@ -24,6 +25,7 @@ WORKDIR /cmake
 RUN wget -q -O- 'https://github.com/Kitware/CMake/releases/download/v3.13.4/cmake-3.13.4-Linux-x86_64.tar.gz' | tar xz
 ENV PATH="/cmake/cmake-3.13.4-Linux-x86_64/bin:$PATH"
 
+COPY pre_install_hook.sh post_install_hook.sh /home/
 # Installing boost from source
 WORKDIR /boost-build
 RUN wget -nv 'https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2' -O - | tar xj && \
@@ -54,15 +56,13 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE, install into /usr/local and clean-up the build directory
 RUN mkdir /home/precice/precice-build && \
+    bash /home/pre_install_hook.sh --dep=precice --ccache && \
     cd /home/precice/precice-build && \
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DBUILD_SHARED_LIBS=ON \
@@ -74,17 +74,14 @@ RUN mkdir /home/precice/precice-build && \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi
+    bash /home/post_install_hook.sh --dep=precice --ccache
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \
     make install && \
     ldconfig
 USER precice
-RUN rm -r /home/precice/precice-build
+RUN rm -rf /home/precice/precice-build ~/.ccache
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1804.home
+++ b/Dockerfile.Ubuntu1804.home
@@ -15,7 +15,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-dev \
     wget \
     bzip2 \
-    cmake && \
+    cmake \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Rebuild image if force_rebuild after that command
@@ -40,6 +42,10 @@ WORKDIR /home/precice/precice
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -53,10 +59,15 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
     make install && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi && \
     rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables

--- a/Dockerfile.Ubuntu1804.home
+++ b/Dockerfile.Ubuntu1804.home
@@ -2,6 +2,8 @@
 
 # Using ubuntu 18.04 as basis
 FROM ubuntu:18.04
+ARG CCACHE_REMOTE
+ENV CCACHE_REMOTE=${CCACHE_REMOTE}
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
@@ -38,20 +40,20 @@ ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
 ARG branch=develop
 RUN git clone --branch $branch https://github.com/precice/precice.git /home/precice/precice
 WORKDIR /home/precice/precice
+COPY post_install_hook.sh pre_install_hook.sh .
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
+#
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE and clean-up generated object files
 RUN mkdir /home/precice/precice-build && \
-    cd /home/precice/precice-build && \
+    bash pre_install_hook.sh --dep=precice --ccache && \
+    cd /home/precice/precice-build
     mkdir /home/precice/precice-install && \
     cmake -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -64,11 +66,8 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make install && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi && \
-    rm -r /home/precice/precice-build
+    bash post_install_hook.sh --dep=precice --cache && \
+    rm -rf /home/precice/precice-build ~/.ccache
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1804.package
+++ b/Dockerfile.Ubuntu1804.package
@@ -24,7 +24,7 @@ RUN apt-get -qq update && apt-get -qq install \
 
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
-
+COPY pre_install_hook.sh post_install_hook.sh /home/
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice
@@ -43,15 +43,13 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE and clean-up generated object files
 RUN mkdir /home/precice/precice-build && \
+    bash /home/pre_install_hook.sh --dep=precice --ccache && \
     cd /home/precice/precice-build && \
     cmake -DBUILD_SHARED_LIBS=ON \
           -DPRECICE_Packages=ON \
@@ -66,12 +64,9 @@ RUN mkdir /home/precice/precice-build && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi && \
+    bash /home/post_install_hook.sh --dep=precice --ccache && \
     mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
-    rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
+    rm -rf /home/precice/precice-build ~/.ccache;
 # user with sudo rights is needed to install preCICE in debian package
 USER root
 RUN cd /home/precice && dpkg -i $(find . -maxdepth 1 -name "*.deb")

--- a/Dockerfile.Ubuntu1804.package
+++ b/Dockerfile.Ubuntu1804.package
@@ -2,6 +2,8 @@
 
 # Using ubuntu 18.04 as basis
 FROM ubuntu:18.04
+# additional variables to sync with the host
+ARG CCACHE_REMOTE
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
@@ -15,7 +17,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-dev \
     wget \
     bzip2 \
-    cmake && \
+    cmake \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Rebuild image if force_rebuild after that command
@@ -39,6 +43,10 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -53,10 +61,15 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
     make package && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi && \
     mv $(find . -maxdepth 1 -name "*.deb") /home/precice && \
     rm -r /home/precice/precice-build  # copy *.deb to home/precice; we do not need the remaining files in precice-build anymore and delete them
 # user with sudo rights is needed to install preCICE in debian package

--- a/Dockerfile.Ubuntu1804.sudo
+++ b/Dockerfile.Ubuntu1804.sudo
@@ -2,6 +2,8 @@
 
 # Using ubuntu 18.04 as basis
 FROM ubuntu:18.04
+# additional variables to sync with the host
+ARG CCACHE_REMOTE
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
@@ -15,7 +17,9 @@ RUN apt-get -qq update && apt-get -qq install \
     python-dev \
     wget \
     bzip2 \
-    cmake && \
+    cmake \
+    rsync \
+    ccache && \
     rm -rf /var/lib/apt/lists/*
 
 # Rebuild image if force_rebuild after that command
@@ -39,6 +43,10 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
+        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
+    fi
+
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -51,9 +59,14 @@ RUN mkdir /home/precice/precice-build && \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test_base
+    make test_base && \
+    if [ ! -z "${CCACHE_REMOTE}" ]; then \
+      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
+      rm -rf ~/.ccache; \
+    fi
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \

--- a/Dockerfile.Ubuntu1804.sudo
+++ b/Dockerfile.Ubuntu1804.sudo
@@ -4,6 +4,7 @@
 FROM ubuntu:18.04
 # additional variables to sync with the host
 ARG CCACHE_REMOTE
+ENV CCACHE_REMOTE=${CCACHE_REMOTE}
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
@@ -39,19 +40,18 @@ ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
 # Building preCICE
 ARG branch=develop
 RUN git clone --branch $branch https://github.com/precice/precice.git /home/precice/precice
+COPY post_install_hook.sh pre_install_hook.sh /home/
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
 # cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
-RUN if [ ! -z "$CCACHE_REMOTE" ]; then\
-        rsync -azpvr ${CCACHE_REMOTE} ~/.ccache; \
-    fi
 
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
 # Build preCICE, install into /usr/local and clean-up the build directory
 RUN mkdir /home/precice/precice-build && \
+    bash /home/pre_install_hook.sh --dep=precice --ccache && \
     cd /home/precice/precice-build && \
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DBUILD_SHARED_LIBS=ON \
@@ -63,17 +63,15 @@ RUN mkdir /home/precice/precice-build && \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test_base && \
-    if [ ! -z "${CCACHE_REMOTE}" ]; then \
-      rsync -azpvr --delete ~/.ccache/ ${CCACHE_REMOTE} &&\
-      rm -rf ~/.ccache; \
-    fi
+    bash /home/post_install_hook.sh --dep=precice --cache
+
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \
     make install && \
     ldconfig
 USER precice
-RUN rm -r /home/precice/precice-build
+RUN rm -rf /home/precice/precice-build ~/.ccache
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/post_install_hook.sh
+++ b/post_install_hook.sh
@@ -1,0 +1,65 @@
+# !/bin/bash
+
+# This partially replicates pre_install_hook.sh with the reverse order of arguments
+# and small adjustments
+# (look in the comment there for the context)
+
+info()
+{
+ cat << EOF
+
+Usage: post_install_hook.sh --prefix=/opt/ --dep=openfoam4
+or to use build caching with  ccache: post_install_hook.sh --dep=SU2 --ccache
+
+EOF
+}
+
+PREFIX="$HOME"
+DEP=""
+CCACHE=false
+
+for arg in "$@"
+do
+  case $arg in
+    --prefix=*)
+      PREFIX="${arg#*=}"
+      shift
+      ;;
+    --dep*|--dependency=*)
+      DEP="${arg#*=}"
+      shift
+      ;;
+    -h|--help*)
+      info
+      exit 0
+      ;;
+      # sync ccache during compilation
+      --ccache)
+      CCACHE=true
+      shift
+      ;;
+    *)
+      printf "Unknown argument:  %s " "$arg"
+      info
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$DEP" ]; then
+  echo "Need to at least provide name of dependency to cache! "
+  info
+  exit 1
+fi
+
+# copy cache back to the individual folder and clean up the leftovers from previous builds
+if [ "$CCACHE" = true ] && [ ! -z "$CCACHE_REMOTE" ]; then
+        rsync -azpvrq --delete ${PREFIX}/.ccache/ ${CCACHE_REMOTE}/${DEP}
+        exit 0
+fi
+
+# if we are on travis and this is the build with the first download, copy it back to the host
+# let the remaining installation instructions in the docker file handle it, otherwise no need to do anything
+if [ ! -z "${DEPS_REMOTE}" ] && [ !{ rsync --list-only "${DEPS_REMOTE}/${DEP}" > /dev/null 2>&1 } ]; then
+  rsync -azpvrq ${PREFIX}/${DEP} ${DEPS_REMOTE}
+fi

--- a/pre_install_hook.sh
+++ b/pre_install_hook.sh
@@ -1,0 +1,85 @@
+# !/bin/bash
+
+# Contains series of operations, that should performed before installing
+# dependenies. This includes caching of their source code to avoid
+# failing builds due to network access on Travis (and corresponding
+# waiting-for-download times ) as well as caching the c++ builds with
+# ccache. Each dependency has individual folder for source
+#  and ccache. Resultant hierarchy is the illustrated below:
+#
+# - cache
+# -- ubuntu1604
+# --- ccache
+# ----- SU2
+# ----- preCICE
+# --- deps
+# ----- SU2
+# ----- preCICE
+
+# It should be used before the chained command that does the compilation or fetches arhieves
+# together with post_install_hook.sh right after the compilation command. In case of usage, please
+# also pipe `return 0`, so that docker treats execution as successfull
+
+info()
+{
+ cat << EOF
+
+Usage: pre_install_hook.sh --prefix=/opt/ --dep=openfoam4
+or to use build caching with  ccache: pre_install_hook.sh --dep=SU2 --ccache
+
+EOF
+}
+
+PREFIX="$HOME"
+DEP=""
+CCACHE=false
+
+for arg in "$@"
+do
+  case $arg in
+    --prefix=*)
+      PREFIX="${arg#*=}"
+      shift
+      ;;
+    --dep*|--dependency=*)
+      DEP="${arg#*=}"
+      shift
+      ;;
+    -h|--help*)
+      info
+      exit 0
+      ;;
+      # sync ccache during compilation
+      --ccache)
+      CCACHE=true
+      shift
+      ;;
+    *)
+      printf "Unknown argument:  %s " "$arg"
+      info
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$DEP" ]; then
+  echo "Need to at least provide name of dependency to cache! "
+  info
+  exit 1
+fi
+
+# sync ccache if we are running on travis and actually want to sync
+if [ "$CCACHE" = true ] && [ ! -z "$CCACHE_REMOTE" ]; then
+        rsync -azpvrq ${CCACHE_REMOTE}/${DEP}/ ${PREFIX}/.ccache
+        exit 0
+fi
+
+# if we are not on travis or folder with the corresponding version was not created yet,
+# let the remaining installation instructions in the docker file handle it
+if [ -z "${DEPS_REMOTE}" ] || [ rsync --list-only "${DEPS_REMOTE}/${DEP}" > /dev/null 2>&1 ]; then
+  exit 0
+# else just copy cached version and don't follow up with any chained commands
+else
+  rsync -azpvrq ${DEPS_REMOTE}/${DEP} ${PREFIX}
+  exit 1
+fi

--- a/setup_ccache_sync.sh
+++ b/setup_ccache_sync.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Starts rsync daemon that allows synchronization of ccache
+# between host and docker container during image build stage
+# use for speeding up build on CI machine
+
+# folder for this particular build
+PROJ_FOLDER=$1
+if [  "$#" -lt 1 ]; then
+  echo "Need to pass name of the folder where to store ccache for this build"
+  exit 1
+fi
+
+# create folder in case they are not cached yet
+mkdir -p $HOME/ccache
+mkdir -p "$HOME/ccache/${PROJ_FOLDER}"
+
+RSYNC_SERVER_IP=$( ip -4 -o addr show docker0 | awk '{print $4}' | cut -d "/" -f 1 )
+RSYNC_CONFIG=$(mktemp)
+# allow access from docker container
+cat <<EOF > "${RSYNC_CONFIG}"
+[precice-docker-cache]
+        path = $HOME/ccache/${PROJ_FOLDER}
+        comment = preCICE docker image cache
+        hosts allow = 172.17.0.2
+        use chroot = false
+        read only = false
+EOF
+RSYNC_PORT=2342
+
+# start rsync in deamon mode
+rsync --port=${RSYNC_PORT} --address="${RSYNC_SERVER_IP}" --config="${RSYNC_CONFIG}" --daemon --no-detach &
+
+CCACHE_REMOTE="rsync://${RSYNC_SERVER_IP}:${RSYNC_PORT}/precice-docker-cache"

--- a/setup_docker_ci_cache.sh
+++ b/setup_docker_ci_cache.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Starts rsync daemon that allows synchronization of files
+# between host and docker container during image build stage
+# use for speeding up build on CI machine, by caching C++ builds
+# with ccache and source code of solvers
+
+VARIANT_FOLDER=$1
+if [  "$#" -lt 1 ]; then
+  echo "Need to pass name of the folder where to store cache for the image variant"
+  exit 1
+fi
+
+# create folders in case they are not cached yet
+mkdir -p "$HOME/cache/${VARIANT_FOLDER}/ccache"
+mkdir -p "$HOME/cache/${VARIANT_FOLDER}/dependencies"
+
+RSYNC_SERVER_IP=$( ip -4 -o addr show docker0 | awk '{print $4}' | cut -d "/" -f 1 )
+RSYNC_CONFIG=$(mktemp)
+# allow access from docker container (we create only one, so name is hardcoded)
+cat <<EOF > "${RSYNC_CONFIG}"
+[build-ccache]
+        path = $HOME/cache/${VARIANT_FOLDER}/ccache
+        comment = preCICE docker image cache
+        hosts allow = 172.17.0.2
+        use chroot = false
+        read only = false
+[dependencies-source-cache]
+        path = $HOME/cache/${VARIANT_FOLDER}/dependencies
+        comment = cache of source code of solvers
+        hosts allow = 172.17.0.2
+        use chroot = false
+        read only = false
+
+EOF
+
+RSYNC_PORT=2342
+
+# start rsync in deamon mode
+rsync --port=${RSYNC_PORT} --address="${RSYNC_SERVER_IP}" --config="${RSYNC_CONFIG}" --daemon --no-detach &
+
+CCACHE_REMOTE="rsync://${RSYNC_SERVER_IP}:${RSYNC_PORT}/build-ccache"
+DEPS_REMOTE="rsync://${RSYNC_SERVER_IP}:${RSYNC_PORT}/dependencies-source-cache"


### PR DESCRIPTION
This adds usage of ccache during building of preCICE images. There is no obvious way to bind the directory on travis to the directory in container during the build so that it can be accessed
( in contrast it is quite easy during running containers as can be see in [this blog post](http://frungy.org/docker/using-ccache-with-docker) ).
The way I went with it  `rsync`-ing directories created during image build and the one, that is cached by Travis, with subsequent removal of extra cache in the image. Everything can still be built without ccache by simply not specifying address from which to `rsync` in the docker `--build-arg`.

I maintain separate cache for different variants (16.04, 18.04), since I am not sure how otherwise things will get messed up. Everything seems to be working as tested on my fork. 

Local testing remains unchanged apart from addition of ccache.

Closes #52
