### PR TITLE
Switch Arch to cmake

### DIFF
--- a/Dockerfile.Arch
+++ b/Dockerfile.Arch
@@ -29,6 +29,8 @@ ARG branch=develop
 RUN git clone --branch $branch https://github.com/precice/precice.git /home/precice/precice
 WORKDIR /home/precice/precice
 
+# add oversubscribe to fix travis
+ENV mpiexec='mpiexec -oversubscribe'
 # Build preCICE and clean-up generated object files
 
 RUN mkdir /home/precice/precice-build && \

--- a/Dockerfile.Arch
+++ b/Dockerfile.Arch
@@ -2,7 +2,7 @@
 
 FROM archlinux/base
 
-RUN pacman -Syu --quiet --noconfirm --needed base-devel boost eigen git scons openmpi python2 python2-numpy
+RUN pacman -Syu --quiet --noconfirm --needed base-devel boost eigen git cmake openmpi python2 python2-numpy
 
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
@@ -11,6 +11,10 @@ RUN pacman -Syu --quiet --noconfirm --needed base-devel boost eigen git scons op
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
+# create user precice
+RUN useradd -ms /bin/bash precice
+USER precice
+WORKDIR /home/precice
 
 # Fixme: This needs to be built as a non-root user.
 # RUN if [ "$petsc_para" ]; then \
@@ -22,16 +26,30 @@ ARG CACHEBUST
 
 # Building preCICE
 ARG branch=develop
-RUN git clone --branch $branch https://github.com/precice/precice.git /precice
-WORKDIR /precice
+RUN git clone --branch $branch https://github.com/precice/precice.git /home/precice/precice
+WORKDIR /home/precice/precice
 
 # Build preCICE and clean-up generated object files
-RUN scons petsc=$petsc_para mpi=$mpi_para python=$python_para -j$(nproc) && \
-    find . -type f \( -name "*.o" -or -name "*.os" \) -exec rm {} +
+
+RUN mkdir /home/precice/precice-build && \
+    cd /home/precice/precice-build && \
+    mkdir /home/precice/precice-install && \
+    cmake -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_INSTALL_PREFIX=/home/precice/precice-install \
+          -DPETSC=$petsc_para \
+          -DMPI=$mpi_para \
+          -DPYTHON=$python_para \
+          /home/precice/precice && \
+    make -j$(nproc) && \
+    make test_base && \
+    make install && \
+    rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/precice"
 ENV LD_LIBRARY_PATH="$PRECICE_ROOT/build/last:${LD_LIBRARY_PATH}" \
+    PKG_CONFIG_PATH="/precice/precice-install/lib/pkgconfig" \
     LIBRARY_PATH="$PRECICE_ROOT/build/last:${LIBRARY_PATH}" \
     CPATH="$PRECICE_ROOT/src:${CPATH}" \
     CPLUS_INCLUDE_PATH="$PRECICE_ROOT/src:${CPLUS_INCLUDE_PATH}"

--- a/Dockerfile.Arch
+++ b/Dockerfile.Arch
@@ -30,7 +30,6 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 WORKDIR /home/precice/precice
 
 # add oversubscribe to fix travis
-ENV mpiexec='mpiexec -oversubscribe'
 # Build preCICE and clean-up generated object files
 
 RUN mkdir /home/precice/precice-build && \
@@ -38,6 +37,7 @@ RUN mkdir /home/precice/precice-build && \
     mkdir /home/precice/precice-install && \
     cmake -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DPRECICE_CTEST_MPI_FLAGS="--oversubscribe" \
           -DCMAKE_INSTALL_PREFIX=/home/precice/precice-install \
           -DPETSC=$petsc_para \
           -DMPI=$mpi_para \


### PR DESCRIPTION
The installation basically mirrors the installation we have for all the the other base images, apart from the dependency part. 

Closes #37. 