### PR TITLE
Use mpich and test mpi ports 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.home-develop:latest
 
   - stage: Building preCICE
-    if: type = cron
+    if: fork = false
     name: "Ubuntu 16.04.sudo"
     script:
     - docker build -f Dockerfile.Ubuntu1604.sudo -t precice .
@@ -41,7 +41,7 @@ jobs:
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop:latest
 
   - stage: Building preCICE
-    if: type = cron
+    if: fork = false
     name: "Ubuntu 16.04.package"
     script:
     - docker build -f Dockerfile.Ubuntu1604.package -t precice .
@@ -53,7 +53,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.home"
-    if: type = cron
+    if: fork = false
     script:
     - docker build -f Dockerfile.Ubuntu1804.home -t precice .
     after_success:
@@ -64,7 +64,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.sudo"
-    if: type = cron
+    if: fork = false
     script:
     - docker build -f Dockerfile.Ubuntu1804.sudo -t precice .
     after_success:
@@ -75,7 +75,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.sudo.mpich"
-    if: type = cron
+    if: fork = false
     script:
     - docker build -f Dockerfile.Ubuntu1804.sudo.mpich -t precice .
     after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,9 @@ jobs:
     name: "Ubuntu 18.04.sudo.mpich"
     if: fork = false
     script:
-    - docker build -f Dockerfile.Ubuntu1804.sudo.mpich -t precice .
+    - docker build -f Dockerfile.Ubuntu1804.sudo.mpich -t $DOCKER_USERNAME/Dockerfile.Ubuntu1804.sudo.mpich-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
 
   - stage: Building preCICE

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,6 @@ jobs:
     - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
 
-
   - stage: Building preCICE
     name: "Ubuntu 18.04.package"
     if: fork = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.home-develop:latest
 
   - stage: Building preCICE
-    if: fork = false
+    if: type = cron
     name: "Ubuntu 16.04.sudo"
     script:
     - docker build -f Dockerfile.Ubuntu1604.sudo -t precice .
@@ -41,7 +41,7 @@ jobs:
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop:latest
 
   - stage: Building preCICE
-    if: fork = false
+    if: type = cron
     name: "Ubuntu 16.04.package"
     script:
     - docker build -f Dockerfile.Ubuntu1604.package -t precice .
@@ -53,7 +53,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.home"
-    if: fork = false
+    if: type = cron
     script:
     - docker build -f Dockerfile.Ubuntu1804.home -t precice .
     after_success:
@@ -64,7 +64,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.sudo"
-    if: fork = false
+    if: type = cron
     script:
     - docker build -f Dockerfile.Ubuntu1804.sudo -t precice .
     after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.sudo.mpich"
-    if: fork = false
+    if: type = cron
     script:
     - docker build -f Dockerfile.Ubuntu1804.sudo.mpich -t $DOCKER_USERNAME/Dockerfile.Ubuntu1804.sudo.mpich-develop .
     after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,18 @@ jobs:
     - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo-develop:latest
 
   - stage: Building preCICE
+    name: "Ubuntu 18.04.sudo.mpich"
+    if: type = cron
+    script:
+    - docker build -f Dockerfile.Ubuntu1804.sudo.mpich -t precice .
+    after_success:
+    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - docker images
+    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
+    - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo.mpich-develop:latest
+
+
+  - stage: Building preCICE
     name: "Ubuntu 18.04.package"
     if: fork = false
     script:

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -40,7 +40,7 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
-# cmake -DPETSC=yes -DMPI=yes -DPYTHON=no -DCMAKE_CXX_COMPILER=mpicxx -j2 /home/precice/precice
+# cmake -DPETSC=yes -DMPI=yes -DPYTHON=no -DCMAKE_CXX_COMPILER=mpicxx -DMPIEXEC_EXECUTABLE=mpiexec -j2 /home/precice/precice
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
@@ -54,6 +54,7 @@ RUN mkdir /home/precice/precice-build && \
           -DMPI=$mpi_para \
           -DPYTHON=$python_para \
           -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx.mpich \
+          -DMPIEXEC_EXECUTABLE=/usr/bin/mpiexec.mpich \
           /home/precice/precice && \
     make -j$(nproc) && \
     make test && \

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -56,7 +56,7 @@ RUN mkdir /home/precice/precice-build && \
           -DMPIEXEC_EXECUTABLE=/usr/bin/mpiexec.mpich \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test  
+    ctest -V  
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -1,0 +1,66 @@
+# Dockerfile for building preCICE on ubuntu 18.04
+
+# Using ubuntu 18.04 as basis
+FROM ubuntu:18.04
+
+# Installing necessary dependacies for preCICE, boost 1.65 from apt-get
+RUN apt-get -qq update && apt-get -qq install \
+    sudo \
+    build-essential \
+    libboost-all-dev \
+    libeigen3-dev \
+    libxml2-dev \
+    petsc-dev \
+    git \
+    python-numpy \
+    python-dev \
+    wget \
+    bzip2 \
+    mpich \
+    cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+# Rebuild image if force_rebuild after that command
+ARG CACHEBUST
+
+# create user precice
+RUN useradd -ms /bin/bash precice && adduser precice sudo
+USER precice
+WORKDIR /home/precice
+
+# Setting some environment variables for installing preCICE
+ENV CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/usr/include/eigen3" \
+    CPATH="/usr/include/eigen3:${CPATH}" \
+    PETSC_DIR="/usr/lib/petscdir/3.6.2/" \
+    PETSC_ARCH="x86_64-linux-gnu-real"
+
+# Building preCICE
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/precice.git /home/precice/precice
+# Some parameters for the build, you can set them in the build command e.g.
+# sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
+# this will result in
+# cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+ARG petsc_para=no
+ARG mpi_para=yes
+ARG python_para=no
+# Build preCICE, install into /usr/local and clean-up the build directory
+RUN mkdir /home/precice/precice-build && \
+    cd /home/precice/precice-build && \
+    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DPETSC=$petsc_para \
+          -DMPI=$mpi_para \
+          -DPYTHON=$python_para \
+          -DCMAKE_CXX_COMPILER=/usr/bin/mpicxx.mpich \
+          /home/precice/precice && \
+    make -j$(nproc) && \
+    make test && \
+    sudo make install && \
+    sudo ldconfig && \
+    rm -r /home/precice/precice-build
+
+# Setting preCICE environment variables
+ENV PRECICE_ROOT="/home/precice/precice" \
+    PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -5,7 +5,6 @@ FROM ubuntu:18.04
 
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
-    sudo \
     build-essential \
     libboost-all-dev \
     libeigen3-dev \
@@ -24,7 +23,7 @@ RUN apt-get -qq update && apt-get -qq install \
 ARG CACHEBUST
 
 # create user precice
-RUN useradd -ms /bin/bash precice && adduser precice sudo
+RUN useradd -ms /bin/bash precice
 USER precice
 WORKDIR /home/precice
 
@@ -57,10 +56,14 @@ RUN mkdir /home/precice/precice-build && \
           -DMPIEXEC_EXECUTABLE=/usr/bin/mpiexec.mpich \
           /home/precice/precice && \
     make -j$(nproc) && \
-    make test && \
-    sudo make install && \
-    sudo ldconfig && \
-    rm -r /home/precice/precice-build
+    make test  
+# user with sudo rights is needed to install preCICE in system directory
+USER root
+RUN cd /home/precice/precice-build && \
+    make install && \
+    ldconfig
+USER precice
+RUN rm -r /home/precice/precice-build
 
 # Setting preCICE environment variables
 ENV PRECICE_ROOT="/home/precice/precice" \

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -56,7 +56,7 @@ RUN mkdir /home/precice/precice-build && \
           -DMPIEXEC_EXECUTABLE=/usr/bin/mpiexec.mpich \
           /home/precice/precice && \
     make -j$(nproc) && \
-    ctest -V  
+    make test
 # user with sudo rights is needed to install preCICE in system directory
 USER root
 RUN cd /home/precice/precice-build && \

--- a/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/Dockerfile.Ubuntu1804.sudo.mpich
@@ -40,7 +40,7 @@ RUN git clone --branch $branch https://github.com/precice/precice.git /home/prec
 # Some parameters for the build, you can set them in the build command e.g.
 # sudo docker build Dockerfile.precice --build-arg petsc_para=yes --build-arg mpi_para=yes .
 # this will result in
-# cmake -DPETSC=yes -DMPI=yes -DPYTHON=no compiler="mpicxx" -j2 /home/precice/precice
+# cmake -DPETSC=yes -DMPI=yes -DPYTHON=no -DCMAKE_CXX_COMPILER=mpicxx -j2 /home/precice/precice
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no


### PR DESCRIPTION
Closes #73 

I added a new Docker base image that uses mpich instead of OpenMPI. This allows running the tests that are expected to fail if we use OpenMPI.