### PR TITLE
Simplify Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     if: fork = false
     name: "Arch Linux"
     script:
-    - docker build -f Dockerfile.Arch -t $DOCKER_USERNAME/precice-arch-develop
+    - docker build -f Dockerfile.Arch -t $DOCKER_USERNAME/precice-arch-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker push $DOCKER_USERNAME/precice-arch-develop:latest
@@ -29,7 +29,7 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.sudo"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.sudo -t $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop
+    - docker build -f Dockerfile.Ubuntu1604.sudo -t $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop:latest
@@ -38,7 +38,7 @@ jobs:
     if: type = cron
     name: "Ubuntu 16.04.package"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.package -t $DOCKER_USERNAME/precice-ubuntu1604.package-develop
+    - docker build -f Dockerfile.Ubuntu1604.package -t $DOCKER_USERNAME/precice-ubuntu1604.package-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.package-develop:latest
@@ -65,7 +65,7 @@ jobs:
     name: "Ubuntu 18.04.package"
     if: fork = false
     script:
-    - docker build -f Dockerfile.Ubuntu1804.package -t $DOCKER_USERNAME/precice-ubuntu1804.package-develop
+    - docker build -f Dockerfile.Ubuntu1804.package -t $DOCKER_USERNAME/precice-ubuntu1804.package-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker push $DOCKER_USERNAME/precice-ubuntu1804.package-develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,44 +11,36 @@ jobs:
     if: fork = false
     name: "Arch Linux"
     script:
-    - docker build -f Dockerfile.Arch -t precice .
+    - docker build -f Dockerfile.Arch -t $DOCKER_USERNAME/precice-arch-develop
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-arch-develop:latest
     - docker push $DOCKER_USERNAME/precice-arch-develop:latest
 
   - stage: Building preCICE
     if: fork = false
     name: "Ubuntu 16.04 home"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.home -t precice .
+    - docker build -f Dockerfile.Ubuntu1604.home -t $DOCKER_USERNAME/precice-ubuntu1604.home-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1604.home-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.home-develop:latest
 
   - stage: Building preCICE
     if: type = cron
     name: "Ubuntu 16.04.sudo"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.sudo -t precice .
+    - docker build -f Dockerfile.Ubuntu1604.sudo -t $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.sudo-develop:latest
 
   - stage: Building preCICE
     if: type = cron
     name: "Ubuntu 16.04.package"
     script:
-    - docker build -f Dockerfile.Ubuntu1604.package -t precice .
+    - docker build -f Dockerfile.Ubuntu1604.package -t $DOCKER_USERNAME/precice-ubuntu1604.package-develop
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1604.package-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1604.package-develop:latest
 
   - stage: Building preCICE
@@ -58,31 +50,25 @@ jobs:
     - docker build -f Dockerfile.Ubuntu1804.home -t precice .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.home-develop:latest
     - docker push $DOCKER_USERNAME/precice-ubuntu1804.home-develop:latest
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.sudo"
     if: type = cron
     script:
-    - docker build -f Dockerfile.Ubuntu1804.sudo -t precice .
+    - docker build -f Dockerfile.Ubuntu1804.sudo -t $DOCKER_USERNAME/precice-ubuntu1804.sudo-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.sudo-develop:latest
-    - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo-develop:latest
+    - docker push $DOCKER_USERNAME/precice-ubuntu1804.sudo-develop
 
   - stage: Building preCICE
     name: "Ubuntu 18.04.package"
     if: fork = false
     script:
-    - docker build -f Dockerfile.Ubuntu1804.package -t precice .
+    - docker build -f Dockerfile.Ubuntu1804.package -t $DOCKER_USERNAME/precice-ubuntu1804.package-develop
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker images
-    - docker tag precice $DOCKER_USERNAME/precice-ubuntu1804.package-develop:latest
-    - docker push $DOCKER_USERNAME/precice-ubuntu1804.package-develop:latest
+    - docker push $DOCKER_USERNAME/precice-ubuntu1804.package-develop
 
   - name: "[Build on fork] Using cached version"
     if: fork = true


### PR DESCRIPTION
This removes not needed commands from Travis config. Building and tagging of an image can be done with one command. `docker images` is not needed also. 