### PR TITLE
Add `allow_failures` section to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 jobs:
   allow_failures:
-  - name: "Ubuntu 18.04.sudo.mpich"
+  - name: "Ubuntu 18.04.sudo.mpich [Job failure permitted]"
     if: type = cron
     script:
     - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,17 @@ python:
   - "3.5"
 services:
   - docker
+
 jobs:
+  allow_failures:
+  - name: "Ubuntu 18.04.sudo.mpich"
+    if: type = cron
+    script:
+    - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .
+    after_success:
+    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
+    - docker push precice/precice-ubuntu1804.sudo.mpich-develop:latest
+
   include:
   - stage: Building preCICE
     if: fork = false
@@ -24,7 +34,7 @@ jobs:
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
     - docker push precice/precice-ubuntu1604.home-develop:latest
-  
+
   - stage: Building preCICE
     if: fork = false
     name: "Ubuntu 16.04 home PETSc"
@@ -125,7 +135,7 @@ jobs:
   - name: FEniCS adapter
     if: fork = false
     script: >
-      docker build -f adapters/Dockerfile.fenics-adapter -t $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop 
+      docker build -f adapters/Dockerfile.fenics-adapter -t $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop
       --build-arg from=precice/precice-ubuntu1804.home-develop .
     after_success:
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
Adds a new section of jobs in the travis.yml file that do not terminate the build after the current stage finishes. Also adds the currently failing Ubuntu1804.sudo.mpich job to this section to allow further stages to run (#102).

For a job to be allowed to fail, it must be specified in _both_ the `include` and `allow_failures` sections. It done so, it will not cause subseqent stages to be cancelled.

**Note**: If every job except for `allow_failures` ones succeeds, the full build will still be marked as successful.