### PR TITLE
Perform `after_success` actions in `deploy` section instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,223 +8,363 @@ services:
 
 jobs:
   allow_failures:
-  - name: "Ubuntu 18.04.sudo.mpich [Job failure permitted]"
-    if: type = cron
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1804.sudo.mpich-develop:latest
+    - name: "Ubuntu 18.04.sudo.mpich [Job failure permitted]"
+      if: type = cron
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1804.sudo.mpich-develop:latest
 
   include:
-  - stage: Building preCICE
-    if: fork = false
-    name: "Arch Linux"
-    script:
-    - docker build -f precice/Dockerfile.Arch -t precice/precice-arch-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-arch-develop:latest
+    - stage: Building preCICE
+      name: "Arch Linux"
+      if: fork = false
+      script:
+        - docker build -f precice/Dockerfile.Arch -t precice/precice-arch-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-arch-develop:latest
 
-  - stage: Building preCICE
-    if: fork = false
-    name: "Ubuntu 16.04 home"
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1604.home -t precice/precice-ubuntu1604.home-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1604.home-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 16.04 home"
+      if: fork = false
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1604.home -t precice/precice-ubuntu1604.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1604.home-develop:latest
 
-  - stage: Building preCICE
-    if: fork = false
-    name: "Ubuntu 16.04 home PETSc"
-    script: >
-      docker build -f precice/Dockerfile.Ubuntu1604.home -t precice/precice-ubuntu1604.home.petsc-develop .
-      --build-arg petsc_para=yes
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1604.home.petsc-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 16.04 home PETSc"
+      if: fork = false
+      script:
+        - >
+          docker build -f precice/Dockerfile.Ubuntu1604.home -t precice/precice-ubuntu1604.home.petsc-develop .
+          --build-arg petsc_para=yes
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1604.home.petsc-develop:latest
 
-  - stage: Building preCICE
-    if: type = cron
-    name: "Ubuntu 16.04.sudo"
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1604.sudo -t precice/precice-ubuntu1604.sudo-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1604.sudo-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 16.04.sudo"
+      if: type = cron
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1604.sudo -t precice/precice-ubuntu1604.sudo-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1604.sudo-develop:latest
 
-  - stage: Building preCICE
-    if: type = cron
-    name: "Ubuntu 16.04.package"
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1604.package -t precice/precice-ubuntu1604.package-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1604.package-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 16.04.package"
+      if: type = cron
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1604.package -t precice/precice-ubuntu1604.package-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1604.package-develop:latest
 
-  - stage: Building preCICE
-    name: "Ubuntu 18.04.home"
-    if: fork = false
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1804.home -t precice .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1804.home-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 18.04.home"
+      if: fork = false
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1804.home -t precice/precice-ubuntu1804.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1804.home-develop:latest
 
-  - stage: Building preCICE
-    name: "Ubuntu 18.04.sudo"
-    if: type = cron
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1804.sudo -t precice/precice-ubuntu1804.sudo-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1804.sudo-develop
+    - stage: Building preCICE
+      name: "Ubuntu 18.04.sudo"
+      if: type = cron
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1804.sudo -t precice/precice-ubuntu1804.sudo-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1804.sudo-develop
 
-  - stage: Building preCICE
-    name: "Ubuntu 18.04.sudo.mpich [Job failure permitted]"
-    if: type = cron
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1804.sudo.mpich-develop:latest
+    - stage: Building preCICE
+      name: "Ubuntu 18.04.sudo.mpich [Job failure permitted]"
+      if: type = cron
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1804.sudo.mpich -t precice/precice-ubuntu1804.sudo.mpich-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1804.sudo.mpich-develop:latest
 
-  - stage: Building preCICE
-    name: "Ubuntu 18.04.package"
-    if: fork = false
-    script:
-    - docker build -f precice/Dockerfile.Ubuntu1804.package -t precice/precice-ubuntu1804.package-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin
-    - docker push precice/precice-ubuntu1804.package-develop
+    - stage: Building preCICE
+      name: "Ubuntu 18.04.package"
+      if: fork = false
+      script:
+        - docker build -f precice/Dockerfile.Ubuntu1804.package -t precice/precice-ubuntu1804.package-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-ubuntu1804.package-develop
 
-  - name: "[Build preCICE on fork] Using cached version"
-    if: fork = true
-    script: true
+    - name: "[Build preCICE on fork] Using cached version"
+      if: fork = true
+      script: true
 
-  - stage: Building adapters
-    script: docker build -f adapters/Dockerfile.su2-adapter -t precice/su2-adapter-ubuntu1604.home-develop .
-    name: SU2 adapter
-    if: fork = false
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin
-    - docker push precice/su2-adapter-ubuntu1604.home-develop
 
-  - name: CalculiX adapter
-    if: fork = false
-    script: docker build -f adapters/Dockerfile.calculix-adapter -t $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin
-    - docker push precice/calculix-adapter-ubuntu1604.home-develop
 
-  - name: deal.ii adapter
-    if: fork = false
-    script: docker build -f adapters/Dockerfile.dealii-adapter -t $DOCKER_USERNAME/dealii-adapter-ubuntu1604.home-develop .
-    after_success:
-      - echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin
-      - docker push precice/dealii-adapter-ubuntu1604.home-develop
+    - stage: Building adapters
+      name: SU2 adapter
+      if: fork = false
+      script:
+        - docker build -f adapters/Dockerfile.su2-adapter -t precice/su2-adapter-ubuntu1604.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin &&
+          docker push precice/su2-adapter-ubuntu1604.home-develop
 
-  - name: openFOAM adapter
-    if: fork = false
-    script: docker build -f adapters/Dockerfile.openfoam-adapter -t $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin
-    - docker push precice/openfoam-adapter-ubuntu1604.home-develop
+    - name: CalculiX adapter
+      if: fork = false
+      script:
+        - docker build -f adapters/Dockerfile.calculix-adapter -t $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin &&
+          docker push precice/calculix-adapter-ubuntu1604.home-develop
 
-  - name: FEniCS adapter
-    if: fork = false
-    script: >
-      docker build -f adapters/Dockerfile.fenics-adapter -t $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop
-      --build-arg from=precice/precice-ubuntu1804.home-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker push $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop
+    - name: deal.ii adapter
+      if: fork = false
+      script:
+        - docker build -f adapters/Dockerfile.dealii-adapter -t $DOCKER_USERNAME/dealii-adapter-ubuntu1604.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin &&
+          docker push precice/dealii-adapter-ubuntu1604.home-develop
 
-  - name: openFOAM adapter [PETSc]
-    if: fork = false
-    script: >
-      docker build -f adapters/Dockerfile.openfoam-adapter -t $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home.petsc-develop
-      --build-arg from=precice/precice-ubuntu1604.home.petsc-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker push $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home.petsc-develop
+    - name: openFOAM adapter
+      if: fork = false
+      script:
+        - docker build -f adapters/Dockerfile.openfoam-adapter -t $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "precice" --password-stdin &&
+          docker push precice/openfoam-adapter-ubuntu1604.home-develop
 
-  - name: CalculiX adapter [PETSc]
-    if: fork = false
-    script: >
-      docker build -f adapters/Dockerfile.calculix-adapter -t $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home.petsc-develop
-      --build-arg from=precice/precice-ubuntu1604.home.petsc-develop .
-    after_success:
-    - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - docker push $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home.petsc-develop
+    - name: FEniCS adapter
+      if: fork = false
+      script:
+        - >
+          docker build -f adapters/Dockerfile.fenics-adapter -t $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop
+          --build-arg from=precice/precice-ubuntu1804.home-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
+          docker push $DOCKER_USERNAME/fenics-adapter-ubuntu1804.home-develop
 
-  - stage: Building adapters
-    if: fork = true
-    name: "[Build adapters on fork] Using cached version"
-    script: true
+    - name: openFOAM adapter [PETSc]
+      if: fork = false
+      script:
+        - >
+          docker build -f adapters/Dockerfile.openfoam-adapter -t $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home.petsc-develop
+          --build-arg from=precice/precice-ubuntu1604.home.petsc-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
+          docker push $DOCKER_USERNAME/openfoam-adapter-ubuntu1604.home.petsc-develop
 
-  - stage: Tests
-    script:
-    - python system_testing.py -s su2-ccx
-    name: "[16.04] SU2 <-> Calculix"
-    after_success:
-    - python push.py -s -t su2-ccx
-    after_failure:
-    - python push.py -t su2-ccx
-  - script:
-    - python system_testing.py -s of-of
-    name: "[16.04] OpenFOAM <-> OpenFOAM"
-    after_success:
-    - python push.py -s -t of-of
-    after_failure:
-    - python push.py -t of-of
-  - script:
-    - python system_testing.py -s of-ccx
-    name: "[16.04] Calculix <-> OpenFOAM"
-    after_success:
-    - python push.py -s -t of-ccx
-    after_failure:
-    - python push.py -t of-ccx
-  - script:
-    - python system_testing.py -s fe-fe --base Ubuntu1804.home
-    name: "[18.04] FEniCS <-> FEniCS"
-    after_success:
-    - python push.py -s -t fe-fe --base Ubuntu1804.home
-    after_failure:
-    - python push.py -t fe-fe --base Ubuntu1804.home
-  - script:
-    - python system_testing.py -s bindings
-    name: "[16.04] Bindings/Solverdummies"
-    after_success:
-    - python push.py -s -t bindings
-    after_failure:
-    - python push.py -t bindings
-  - script:
-    - python system_testing.py -s dealii-of
-    name: "[16.04] deal.ii <-> OpenFOAM"
-    after_success:
-    - python push.py -s -t dealii-of
-    after_failure:
-    - python push.py -t dealii-of
-  - script:
-    - python system_testing.py -s nutils-of
-    name: "[16.04] nutils <-> OpenFOAM"
-    after_success:
-    - python push.py -s -t nutils-of
-    after_failure:
-    - python push.py -t nutils-of
-  - script:
-    - python system_testing.py -s of-of_np
-    name: "[16.04] OpenFOAM <-> OpenFOAM [nearest projection]"
-    after_success:
-    - python push.py -s -t of-of_np
-    after_failure:
-    - python push.py -t of-of_np
-  - script:
-    - python system_testing.py -s of-ccx_fsi --base Ubuntu1604.home.PETSc
-    name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI]"
-    after_success:
-    - python push.py -s -t of-ccx_fsi
-    after_failure:
-    - python push.py -t of-ccx_fsi
+    - name: CalculiX adapter [PETSc]
+      if: fork = false
+      script:
+        - >
+          docker build -f adapters/Dockerfile.calculix-adapter -t $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home.petsc-develop
+          --build-arg from=precice/precice-ubuntu1604.home.petsc-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin &&
+          docker push $DOCKER_USERNAME/calculix-adapter-ubuntu1604.home.petsc-develop
+
+    - name: "[Build adapters on fork] Using cached version"
+      if: fork = true
+      script: true
+
+
+
+    - stage: Tests
+      name: "[16.04] SU2 <-> Calculix"
+      script:
+        - python system_testing.py -s su2-ccx
+      after_failure:
+        - python push.py -t su2-ccx
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t su2-ccx
+
+    - name: "[16.04] OpenFOAM <-> OpenFOAM"
+      script:
+        - python system_testing.py -s of-of
+      after_failure:
+        - python push.py -t of-of
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t of-of
+
+    - name: "[16.04] Calculix <-> OpenFOAM"
+      script:
+        - python system_testing.py -s of-ccx
+      after_failure:
+        - python push.py -t of-ccx
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t of-ccx
+
+    - name: "[18.04] FEniCS <-> FEniCS"
+      script:
+        - python system_testing.py -s fe-fe --base Ubuntu1804.home
+      after_failure:
+        - python push.py -t fe-fe --base Ubuntu1804.home
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t fe-fe --base Ubuntu1804.home
+
+    - name: "[16.04] Bindings/Solverdummies"
+      script:
+        - python system_testing.py -s bindings
+      after_failure:
+        - python push.py -t bindings
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t bindings
+
+    - name: "[16.04] deal.ii <-> OpenFOAM"
+      script:
+        - python system_testing.py -s dealii-of
+      after_failure:
+        - python push.py -t dealii-of
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t dealii-of
+
+    - name: "[16.04] nutils <-> OpenFOAM"
+      script:
+        - python system_testing.py -s nutils-of
+      after_failure:
+        - python push.py -t nutils-of
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t nutils-of
+
+    - name: "[16.04] OpenFOAM <-> OpenFOAM [nearest projection]"
+      script:
+        - python system_testing.py -s of-of_np
+      after_failure:
+        - python push.py -t of-of_np
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t of-of_np
+
+    - name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI]"
+      script:
+        - python system_testing.py -s of-ccx_fsi --base Ubuntu1604.home.PETSc
+      after_failure:
+        - python push.py -t of-ccx_fsi
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: python push.py -s -t of-ccx_fsi

--- a/docs/adding_tests.md
+++ b/docs/adding_tests.md
@@ -1,0 +1,82 @@
+# How to add tests
+
+To add a new test to the Travis build, simply add a corresponding entry in the `.travis.yml` file in a fitting stage under the `jobs: include:` section. The current stages are `Building preCICE`, `Building adapters`, `Tests`.
+
+Here is an example job which builds the SU2 adapter:
+
+```bash
+- stage: Building adapters
+  name: SU2 adapter
+  if: fork = false
+  script:
+    - docker build -f adapters/Dockerfile.su2-adapter -t precice/su2-adapter-ubuntu1604.home-develop .
+```
+
+An entry should at least contain `name` and `script` keys such that the job can be run by travis and identified in the build log. In this example the additional `if` conditions avoids this job to execute if the build is running on a fork of the systemtests repository. Many more specifications are available if necessary, check the [Travis docs](https://docs.travis-ci.com/) for more info.
+
+## Post-script actions
+
+Most likely your preCICE build/adapter build/adapter test outputs some result data at the end, which should be either pushed to DockerHub (for docker images) of the 'precice_st_output' repository (for test logs). These pushes can be conditional as well, e.g. only pushing a docker image if the build actually exited successfully.
+Such conditional pushes are realized by adding specific commands in `after_failure` and `deploy` sections.
+
+#### Post-failure
+
+Here is an example of how to use the `after_failure` key:
+```bash
+  - stage: Tests
+    name: "[16.04] SU2 <-> Calculix"
+    script:
+      - python system_testing.py -s su2-ccx
+    after_failure:
+      - python push.py -t su2-ccx
+```
+Youc can specify commands the same way you do for the main script. This code will only be run if the main script commands return a non-zero exit code.
+
+#### Post-success
+
+**Note**: `after_success` sections are available in TravisCI. However, it is strongly recommended to use `deploy`. The reason is that a build with failing code in `after_success` sections will still get shown as successful, which makes it harder to detect failures.
+
+A deployment requires several additional arguments to function properly. These do not need to be specifically adjusted for your test and can be directly copied into your test. Here is an code snippet from a deploying job:
+
+```bash
+    - stage: Building preCICE
+      name: "Arch Linux"
+      if: fork = false
+      script:
+        - docker build -f precice/Dockerfile.Arch -t precice/precice-arch-develop .
+      deploy:
+        skip_cleanup: true
+        provider: script
+        on:
+          all_branches: true
+        script: >-
+          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
+          docker push precice/precice-arch-develop:latest
+```
+
+The `deploy: script` contains the actual commands you wish to execute after a successful run. Additionally, the following arguments must be provided inside the `deploy` key:
+
+- `skip_cleanup: true`
+
+  This prevents TravisCI from stashing all changes made during the build, i.e. cleaning all results we actually wish to push.
+
+
+- `provider: script`
+
+  Specifies that the deployment phase uses our manually provided script.
+
+
+- `on: all_branches: true`
+
+  With this the deployment can be issued on any branch. This allows us to execute commands from the same branch that triggered a Travis build, and for any branch. If this key is not set, the deployment scripts would be run exclusively on `master` instead (independent of which branch the build runs on).
+
+
+- `script: >-   [actual deploy script]`
+
+  The `>-` is *critical* here. For one, **deploy scripts can only consist of a single line**. This means that we have to chain commands together (note the `&&` at line end) and use `>` to extend them into multiple lines. The addition of the hyphen `-` prevents the last command to be trailed by a newline character `/n`. **If this hyphen is omitted, the `/n` character in the command might get parsed as only `n`, which appends a character to the final command and makes it invalid!**
+
+
+
+## Need help setting up a test?
+
+If you are experiencing any issues, don't hesitate to ask for assisstance on [Gitter](https://gitter.im/precice/Lobby) or [Discourse](https://precice.discourse.group/).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # General architecture
 
-When running on Travis tests are executed in the several stages that are outlined below. 
-When it comes to local tests, steps are identical, but the push to the remote dockerhub repository is absent.
+When running on Travis tests are executed as specified in the file `.travis.yml` located in the root of the systemtests repository. The several stages of testing are outlined below.
+If running a local tests (compared to the standard build on the Travis servers) the steps are identical, but the push to the remote DockerHub repository is absent.
 
 ## Building preCICE
 
@@ -17,9 +17,8 @@ Resulting images are then stored on the [Dockerhub](https://hub.docker.com/u/pre
 
 ## Building adapters
 
-
 To build an adapter we follow a two-stage build, first importing from the preCICE image and then importing from the solver's image
-(if the solver's image is actually relevant for building the adapter).We can import from different preCICE base images by specifying `from` 
+(if the solver's image is actually relevant for building the adapter).We can import from different preCICE base images by specifying `from`
 argument during building of the image, e.g:
 ```
 docker build --build-arg from=precice/precice-ubuntu1804.home-develop -d Dockerfile.openfoam-adapter -t openfoam-adapter-ubuntu1804.home-develop .


### PR DESCRIPTION
Closes #103 .

---
For our systemtests builds, we intend that after each job finishes, some form of result will be pushed to an external hub (DockerHub or `precice_st_output`) based on the success of the job. This is currently done by specifying `after_success` and `after_failure` keys in the `.travis.yml` configuration file with the relevant pushing commands.

However, TravisCI [by design](https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build) does not factor in the success of these post-job commands when expressing the exit status of the build. In the case of a failure in the `after_success` commands, the build will still be marked as success (jobs executing the `after_failure` sections will rightfully get marked as failures).

---
To circumvent this issue, we can instead designate `after_success` commands as `deploy` commands. These sections are only executed if the job succeeds and will cause the job to be marked as failed if the deploy fails.
This PR replaces all current `after_success` sections with deployments and adds documentation on how to add tests and handle `after_failure` and `deploy` sections.

Note: If a job fails during its main commands (e.g. while building an adapter) the build will get marked as '**failed**'. If a job fails during its deployment phase, it gets marked as '**errored**' instead.

### How to use `deploy`

For adding jobs in the future it should be noted that compared to `after_success` sections, deploys require a few additional arguments to function properly. Here is an code snippet from one of the jobs:
```bash
    - stage: Building preCICE
      name: "Arch Linux"
      if: fork = false
      script:
        - docker build -f precice/Dockerfile.Arch -t precice/precice-arch-develop .
      deploy:
        skip_cleanup: true
        provider: script
        on:
          all_branches: true
        script: >-
          echo "$DOCKER_PASSWORD" | docker login -u precice --password-stdin &&
          docker push precice/precice-arch-develop:latest
```
In addition to the actual deploy script, the following arguments must be provided inside of the `deploy` key:
- `skip_cleanup: true` - this prevents TravisCI from stashing all changes made during the build, i.e. cleaning up our actual results.
- `provider: script` - specifies that the deployment happens through our manually provided script.
- `on: all_branches: true` - the deployment can be issued on any branch. This allows us to execute commands from the same branch that triggered a travis build, for any branch. Otherwise the deployment scripts would be run exclusively on `master`, independent of which branch executed the main script.
- `script: >-   [actual push script]` - The `>-` is *critical* here. For one, **deploy scripts can only consist of a single line**. This means that we have to chain commands together (note the `&&` at line end) and use `>` to extend them into multiple lines. The addition of the hyphen `-` prevents the last command to be trailed by a newline character `/n`. **If this hyphen is omitted, the `/n` character in the command might get parsed as only `n`, which appends a character to the final command and makes it invalid!**
