### PR TITLE
Use branch develop as default for all tests

### DIFF
--- a/adapters/Dockerfile.calculix-adapter
+++ b/adapters/Dockerfile.calculix-adapter
@@ -26,7 +26,8 @@ USER precice
 # get calculix source
 WORKDIR /home/precice
 RUN curl -s http://www.dhondt.de/ccx_2.15.src.tar.bz2 | tar -xj
-RUN git clone https://github.com/precice/calculix-adapter.git
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/calculix-adapter.git
 WORKDIR calculix-adapter/
 # specify proper locations of libraries
 RUN sed -i  -e 's|CCX\s\+=.*|CCX	= /home/precice/CalculiX/ccx_2.15/src|g'\

--- a/adapters/Dockerfile.dealii-adapter
+++ b/adapters/Dockerfile.dealii-adapter
@@ -9,7 +9,8 @@ COPY --from=deal.ii /root/dealii/ /home/precice/dealii/
 
 USER precice
 WORKDIR /home/precice
-RUN git clone https://github.com/precice/dealii-adapter.git
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/dealii-adapter.git
 RUN cd dealii-adapter && \
     cmake -DDEAL_II_DIR=$HOME/dealii -DDIM=3 -DCMAKE_BUILD_TYPE=Release . && \
     make -j $(nproc) 

--- a/adapters/Dockerfile.fenics-adapter
+++ b/adapters/Dockerfile.fenics-adapter
@@ -43,7 +43,8 @@ ARG CACHEBUST
 
 # Building fenics-adapter
 WORKDIR /home/precice
-RUN git clone https://github.com/precice/fenics-adapter.git && \
+ARG branch=develop
+RUN git clone  --branch $branch https://github.com/precice/fenics-adapter.git && \
     cd fenics-adapter && \
     pip3 install --user . && \
     python3 setup.py test

--- a/adapters/Dockerfile.openfoam-adapter
+++ b/adapters/Dockerfile.openfoam-adapter
@@ -20,7 +20,8 @@ COPY --from=openfoam /opt/openfoam4 /opt/openfoam4/
 # Building openfoam-adapter
 USER precice
 WORKDIR /home/precice
-RUN git clone https://github.com/precice/openfoam-adapter.git
+ARG branch=develop
+RUN git clone  --branch $branch https://github.com/precice/openfoam-adapter.git
 WORKDIR /home/precice/openfoam-adapter
 RUN . /opt/openfoam4/etc/bashrc && ./Allwmake
 RUN cd $HOME && mkdir -p Data/Input Data/Output Data/Exchange

--- a/adapters/Dockerfile.su2-adapter
+++ b/adapters/Dockerfile.su2-adapter
@@ -24,8 +24,9 @@ ENV SU2_HOME="/home/precice/su2-source" \
     PATH="/home/precice/su2-bin/bin:${PATH}" \
     PYTHONPATH="/home/precice/su2-bin/bin:${PYTHONPATH}"
 
+ARG branch=develop
 RUN cd /home/precice && \
-    git clone https://github.com/precice/su2-adapter.git && cd su2-adapter &&  \
+    git clone --branch $branch https://github.com/precice/su2-adapter.git && cd su2-adapter &&  \
     ./su2AdapterInstall
 
 WORKDIR /home/precice/su2-source

--- a/tests/TestCompose_dealii-of/Dockerfile.tutorial_data
+++ b/tests/TestCompose_dealii-of/Dockerfile.tutorial_data
@@ -2,7 +2,8 @@ from alpine
 ENV tutorial_path tutorials/FSI/flap_perp/OpenFOAM-deal.II
 RUN apk add git
 
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 RUN mkdir configs && sed -e 's|gather-scatter"|gather-scatter" exchange-directory="/home/precice/Data/Exchange/" network="eth0"|g' $tutorial_path/precice-config_serial.xml > configs/precice-config.xml
 RUN sed -i '/application     pimpleFoam/d; s/\/\/ application     pimpleDyMFoam/application    pimpleDyMFoam/g' \
     $tutorial_path/Fluid/system/controlDict

--- a/tests/TestCompose_fe-fe.Ubuntu1804.home/Dockerfile.tutorial_data
+++ b/tests/TestCompose_fe-fe.Ubuntu1804.home/Dockerfile.tutorial_data
@@ -1,8 +1,8 @@
 from alpine
 ENV tutorial_path tutorials/HT/partitioned-heat/fenics-fenics
 RUN apk add git
-
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 RUN mkdir configs && sed -i 's|network="lo"|exchange-directory="/home/precice/Data/Exchange/" network="eth0"|g' $tutorial_path/precice-config.xml
 
 RUN addgroup -g 1000 precice && adduser -u 1000 -G precice -D precice && chown -R precice:precice tutorials configs

--- a/tests/TestCompose_nutils-of/Dockerfile.tutorial_data
+++ b/tests/TestCompose_nutils-of/Dockerfile.tutorial_data
@@ -2,7 +2,8 @@ from alpine
 
 ENV tutorial_path /tutorials/CHT/flow-over-plate/buoyantPimpleFoam-nutils
 RUN apk add git
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 
 WORKDIR /
 # adjust configuration and paths

--- a/tests/TestCompose_of-ccx/Dockerfile.tutorial_data
+++ b/tests/TestCompose_of-ccx/Dockerfile.tutorial_data
@@ -2,7 +2,8 @@ from alpine
 
 ENV tutorial_path /tutorials/CHT/heat_exchanger/buoyantSimpleFoam-CalculiX
 RUN apk add git bash
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 
 # Copy modified configs
 COPY controlDict $tutorial_path/Inner-Fluid/system/controlDict

--- a/tests/TestCompose_of-ccx_fsi.Ubuntu1604.home.PETSc/Dockerfile.tutorial_data
+++ b/tests/TestCompose_of-ccx_fsi.Ubuntu1604.home.PETSc/Dockerfile.tutorial_data
@@ -2,7 +2,8 @@ from alpine
 
 ENV tutorial_path /tutorials/FSI/flap_perp/OpenFOAM-CalculiX
 RUN apk add git bash
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 
 WORKDIR /
 

--- a/tests/TestCompose_su2-ccx/Dockerfile.tutorial_data
+++ b/tests/TestCompose_su2-ccx/Dockerfile.tutorial_data
@@ -1,7 +1,8 @@
 from alpine
 ENV tutorial_path tutorials/FSI/flap_perp/SU2-CalculiX
 RUN apk add git bash
-RUN git clone https://github.com/precice/tutorials
+ARG branch=develop
+RUN git clone --branch $branch https://github.com/precice/tutorials
 
 RUN mkdir configs && sed -e 's|exchange-directory="../"|exchange-directory="/home/precice/Data/Exchange/" network="eth0"|g'\ 
     $tutorial_path/precice-config_serial.xml  > configs/precice-config.xml


### PR DESCRIPTION
We want to test against the develop version of the branches, not against the master version. Therefore, we explicitly add the option `--branch` for all tests where we `git clone` preCICE/an adapter/a tutorial.

### Why do we do this?

Currently, we cannot really test breaking changes without introducing the breaking changes to the whole toolchain. We agreed on allowing breaking changes on the `develop` branches of all `precice/` repositories (thus we can ensure compatibility). 

In order to avoid that our users have to deal with these breaking changes before the official release, we make sure to only update `master`for all `precice/` repositories via a PR from `develop` as soon as the new preCICE version (including the breaking changes) is officially released.