### PR TITLE
Revert "Add tests for bindings on Ubuntu 18.04 (#129)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -325,18 +325,6 @@ jobs:
           all_branches: true
         script: python push.py -s -t bindings
 
-    - name: "[18.04] Bindings/Solverdummies"
-      script:
-        - python system_testing.py -s bindings --base Ubuntu1804.home
-      after_failure:
-        - python push.py -t bindings --base Ubuntu1804.home
-      deploy:
-        skip_cleanup: true
-        provider: script
-        on:
-          all_branches: true
-        script: python push.py -s -t bindings --base Ubuntu1804.home
-
     - name: "[16.04] deal.ii <-> OpenFOAM"
       script:
         - python system_testing.py -s dealii-of


### PR DESCRIPTION
This reverts commit 41581e838945d44f597d37ae02844ddc5bcaa133.

The test currently fails: https://travis-ci.org/precice/systemtests/jobs/641699804#L619

```
Step 9/27 : RUN pip3 install --user https://github.com/[secure]/python-bindings/archive/$branch.zip
 ---> Running in 0bcd0de24d6c
Collecting https://github.com/[secure]/python-bindings/archive/develop.zip
  Downloading https://github.com/[secure]/python-bindings/archive/develop.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-6heok3m8-build/setup.py", line 12, in <module>
        from packaging import version
    ModuleNotFoundError: No module named 'packaging'
```