### PR TITLE
Update python solverdummy location

### DIFF
--- a/tests/Test_bindings.Ubuntu1804/Dockerfile
+++ b/tests/Test_bindings.Ubuntu1804/Dockerfile
@@ -18,12 +18,15 @@ USER precice
 
 ARG branch=develop
 
-# Builds the precice python bindings for python3
-RUN pip3 install --user https://github.com/precice/python-bindings/archive/$branch.zip
+# Clones the precice python bindings
+WORKDIR /home/precice
+RUN git clone https://github.com/precice/python-bindings/archive/$branch.zip
+# Builds the precice python bindings
+WORKDIR /home/precic/python-bindings
+RUN pip3 install --user .
 
-# Runs the python solverdummy with python3
-WORKDIR $PRECICE_ROOT/tools/solverdummies/python
-RUN python3 solverdummy.py ../precice-config.xml SolverOne MeshOne & python3 solverdummy.py ../precice-config.xml SolverTwo MeshTwo
+# Runs the python solverdummy
+RUN cd solverdummy && python3 solverdummy.py precice-config.xml SolverOne MeshOne & python3 solverdummy.py precice-config.xml SolverTwo MeshTwo
 
 # Builds the C solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/c

--- a/tests/Test_bindings/Dockerfile
+++ b/tests/Test_bindings/Dockerfile
@@ -23,12 +23,15 @@ RUN pip3 install --user cython mpi4py numpy enum34
 
 ARG branch=develop
 
-# Builds the precice python bindings for python3
-RUN pip3 install --user https://github.com/precice/python-bindings/archive/$branch.zip
+# Clones the precice python bindings
+WORKDIR /home/precice
+RUN git clone https://github.com/precice/python-bindings/archive/$branch.zip
+# Builds the precice python bindings
+WORKDIR /home/precic/python-bindings
+RUN pip3 install --user .
 
-# Runs the python solverdummy with python3
-WORKDIR $PRECICE_ROOT/tools/solverdummies/python
-RUN python3 solverdummy.py ../precice-config.xml SolverOne MeshOne & python3 solverdummy.py ../precice-config.xml SolverTwo MeshTwo
+# Runs the python solverdummy
+RUN cd solverdummy && python3 solverdummy.py precice-config.xml SolverOne MeshOne & python3 solverdummy.py precice-config.xml SolverTwo MeshTwo
 
 # Builds the C solverdummy
 WORKDIR $PRECICE_ROOT/tools/solverdummies/c


### PR DESCRIPTION
This change is necessary since the python solverdummy has been moved from https://github.com/precice/precice to https://github.com/precice/python-bindings. See https://github.com/precice/precice/commit/a0a828b49b47d8f79ae10b97d714c006427cba36 and https://github.com/precice/python-bindings/commit/b1fb12b610b11fef7774acacee6224a007e8c689.