### PR TITLE
Add installation of pkg-config

### DIFF
--- a/precice/Dockerfile.Ubuntu1604.home
+++ b/precice/Dockerfile.Ubuntu1604.home
@@ -12,6 +12,7 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
+    pkg-config \    
     bzip2 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/precice/Dockerfile.Ubuntu1604.package
+++ b/precice/Dockerfile.Ubuntu1604.package
@@ -12,6 +12,7 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
+    pkg-config \
     bzip2 && \
     rm -rf /var/lib/apt/lists/*
 

--- a/precice/Dockerfile.Ubuntu1604.sudo
+++ b/precice/Dockerfile.Ubuntu1604.sudo
@@ -12,6 +12,7 @@ RUN apt-get -qq update && apt-get -qq install \
     python-numpy \
     python-dev \
     wget \
+    pkg-config \
     bzip2 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
https://github.com/precice/systemtests/commit/72a0bd76ee7360f216f70d2d88a08e797e7361af switched from installing eigen via `apt` to installing eigen from source. This results in also not installing `pkg-config` that is a dependency of eigen. Therefore we now have to individually install `pkg-config`. Otherwise builds under Ubuntu16.04 relying on `pkg-config` will fail. See [SU2 build](https://travis-ci.org/precice/systemtests/jobs/644357604#L795-L796) and [CalculiX build](https://travis-ci.org/precice/systemtests/jobs/644357605#L667-L668).