### PR TITLE
Add comments pointing to #186

### DIFF
--- a/adapters/Dockerfile.fenics-adapter
+++ b/adapters/Dockerfile.fenics-adapter
@@ -26,6 +26,7 @@ RUN add-apt-repository -y ppa:fenics-packages/fenics && \
     apt-get -qq install --no-install-recommends fenics && \
     rm -rf /var/lib/apt/lists/*
 
+# Using pip3 pip-wrapper will trigger a warning. See https://github.com/precice/systemtests/issues/186.
 RUN pip3 install --user cython  # TODO: can we put this dependency into requirements.txt of python?
 
 USER precice

--- a/tests/TestCompose_nutils-of.Ubuntu1804.home/Dockerfile.nutils
+++ b/tests/TestCompose_nutils-of.Ubuntu1804.home/Dockerfile.nutils
@@ -6,6 +6,7 @@ RUN apt-get -qq update && apt-get -qq install \
     python3 python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# Using pip3 pip-wrapper will trigger a warning. See https://github.com/precice/systemtests/issues/186.
 RUN wget -q https://bootstrap.pypa.io/get-pip.py -O get-pip.py && \
     python3 get-pip.py && \
     pip3 install Cython mpi4py numpy

--- a/tests/Test_bindings.Ubuntu1604.home/Dockerfile
+++ b/tests/Test_bindings.Ubuntu1604.home/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /home/precice
 RUN git clone --branch $branch https://github.com/precice/python-bindings.git
 # Builds the precice python bindings
 WORKDIR /home/precice/python-bindings
+# Using pip3 pip-wrapper will trigger a warning. See https://github.com/precice/systemtests/issues/186.
 RUN pip3 install --user .
 
 # Runs the python solverdummy

--- a/tests/Test_bindings.Ubuntu1804.home/Dockerfile
+++ b/tests/Test_bindings.Ubuntu1804.home/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /home/precice
 RUN git clone --branch $branch https://github.com/precice/python-bindings.git
 # Builds the precice python bindings
 WORKDIR /home/precice/python-bindings
+# Using pip3 pip-wrapper will trigger a warning. See https://github.com/precice/systemtests/issues/186.
 RUN pip3 install --user .
 
 # Runs the python solverdummy


### PR DESCRIPTION
Like discussed in #186 using `pip3` will trigger a warning, if a recent `pip` version is used. However, https://github.com/precice/systemtests/issues/186#issuecomment-591887545 gives reasons to keep using `pip3` (at least for a while). This PR adds comments in the code to point developers to the corresponding issue.