### PR TITLE
Add new path for dealii adapter in develop

### DIFF
--- a/adapters/Dockerfile.dealii-adapter
+++ b/adapters/Dockerfile.dealii-adapter
@@ -10,7 +10,7 @@ COPY --from=deal.ii /root/dealii/ /home/precice/dealii/
 USER precice
 WORKDIR /home/precice
 RUN git clone https://github.com/precice/dealii-adapter.git
-RUN cd dealii-adapter && \
+RUN cd dealii-adapter/coupled_elasto_dynamics/ && \
     cmake -DDEAL_II_DIR=$HOME/dealii -DDIM=3 -DCMAKE_BUILD_TYPE=Release . && \
     make -j $(nproc) 
 


### PR DESCRIPTION
According to our intention to add a new solver for deal ii, I rearranged the dealii-adapter structure a bit i.e I moved the linear solver to a separate directory and opened up a directory for the (upcoming) non-linear solver. 
AfaIk, the systemtests are triggered for the develop branches, hence we need to switch our travis path, to avoid failing tests. 
@uekerman Are you fine with [the new structure?](https://github.com/precice/dealii-adapter/tree/develop)
@Eder-K Is this all I need to do, to fix the systemtests?