### PR TITLE
Fix inconsistent output in 1dtube test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -314,12 +314,12 @@ jobs:
     - name: "[16.04] Elastictube1D - Python"
       script:
         - python system_testing.py -s 1dtube_py -v
-        - python push.py --test 1dtube_py -o
+        - python push.py --test 1dtube_py
 
     - name: "[16.04] Elastictube1D - C++"
       script:
         - python system_testing.py -s 1dtube_cxx -v
-        - python push.py --test 1dtube_cxx -o
+        - python push.py --test 1dtube_cxx
 
     - name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI] [Job failure permitted]"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -314,12 +314,12 @@ jobs:
     - name: "[16.04] Elastictube1D - Python"
       script:
         - python system_testing.py -s 1dtube_py -v
-        - python push.py --test 1dtube_py
+        - python push.py --test 1dtube_py -o
 
     - name: "[16.04] Elastictube1D - C++"
       script:
         - python system_testing.py -s 1dtube_cxx -v
-        - python push.py --test 1dtube_cxx
+        - python push.py --test 1dtube_cxx -o
 
     - name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI] [Job failure permitted]"
       script:

--- a/compare_results.sh
+++ b/compare_results.sh
@@ -100,13 +100,13 @@ if [ -n "$diff_files" ]; then
     if [ -n "$rel_max_difference" ]; then
       # Split by space and transform into the array
       difference=( $rel_max_difference )
-      echo -e "> Numerical difference in $file1 and $file2"
+      echo -e "> Numerical difference in $filename"
       echo -e "$num_diff"
       echo -e "Average: ${difference[0]} ; Maximum: ${difference[1]} ${NC}"
       ret=1
     fi
     if [ -n "$txt_diff" ]; then
-      echo -e "> Text difference in $file1 and $file2"
+      echo -e "> Text difference in $filename"
       echo -e "$txt_diff"
       ret=1
     fi

--- a/compare_results.sh
+++ b/compare_results.sh
@@ -67,7 +67,7 @@ if [ -n "$diff_files" ]; then
     num_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]\|[vV]ersion/d'
     # Filter for text lines. Compare these seperately from numerical lines
     # Ignore any timestamps
-    txt_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]\|[vV]ersion/!d; s/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]//g; /Timestamp\|[rR]untime\|Unexpected end of/d; /Run finished/q'
+    txt_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]/!d; s/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]//g; /Timestamp\|[rR]untime\|[vV]ersion\|[rR]evision\|Unexpected end of/d; /Run finished/q'
     file1_num=$( cat "$file1" | sed "$num_filter")
     file2_num=$( cat "$file2" | sed "$num_filter")
 


### PR DESCRIPTION
Closes #223.

This allows the comparison script to ignore preCICE revision information.