### PR TITLE
Update reference files for 1dtube tests

### DIFF
--- a/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/Dockerfile.tutorial_data
+++ b/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/Dockerfile.tutorial_data
@@ -6,5 +6,5 @@ ARG branch=develop
 WORKDIR /
 # adjust configuration and paths
 RUN mkdir Output
-RUN addgroup -g 1000 precice && adduser -u 1000 -G precice -D precice Output
+RUN addgroup -g 1000 precice && adduser -u 1000 -G precice -D precice && chown -R precice:precice Output
 USER precice

--- a/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/docker-compose.yml
+++ b/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         cp *.log /home/precice/Data/Output/ &&
         cp -r Postproc /home/precice/Data/Output/ &&
         rm /home/precice/Data/Output/*summary.log"
-    container_name: 1dtube-ccx
+    container_name: 1dtube-cxx
 
   tutorial-data:
     build:

--- a/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/referenceOutput/Fluid.log
+++ b/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/referenceOutput/Fluid.log
@@ -1,828 +1,828 @@
 Starting Fluid Solver...
 N: 100 tau: 0.01 kappa: 100
 Configure preCICE...
-Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/4SC56LF3HVRK544D6UBZC2VBF6:/var/lib/docker/overlay2/l/VELHVVSTWHP5PBCXW6ISXV54YF:/var/lib/docker/overlay2/l/FZCZPUYFHFHJHYYLRJDQVDN3Y4:/var/lib/docker/overlay2/l/R6CDUM3R4BRL72OF7HM4OE4ZKZ:/var/lib/docker/overlay2/l/TTGFLT2GQJRTXXX42Q7LKLX5V4:/var/lib/docker/overlay2/l/Q763VSE3LEMXV2IOPOU3O2LJRX:/var/lib/docker/overlay2/l/MOOWAB7TLKH6MGFYQXXILS3FKE:/var/lib/docker/overlay2/l/44LBYLVBBUNNFAUP5RUDWQCMLN:/var/lib/docker/overlay2/l/STLE4NK37NAAP'
-Unexpected end of /proc/mounts line `KWBJEUVNYRRQ2:/var/lib/docker/overlay2/l/VEX7AUYLW52VRXP763KYUWBM6J:/var/lib/docker/overlay2/l/B4AAZBCUXFFVZFMYOJSTC7XDMD:/var/lib/docker/overlay2/l/4GB57N2RV75GNIJZ7Z2FPRTI5D:/var/lib/docker/overlay2/l/PENZ6SRQSXINRZJWII25STOKZS:/var/lib/docker/overlay2/l/J6UFTARNBX7TRO7DCKQKQJMMYK:/var/lib/docker/overlay2/l/GA74WG2GHI7X5PD7AINOBA35U3:/var/lib/docker/overlay2/l/B4TDE74BCCFM2AEZ5EDTK3LGB5:/var/lib/docker/overlay2/l/F6KSORICGXNQPFZ47NCBR3SQHG:/var/lib/docker/overlay2/l/FKBOMOD2SES4HBT77IA42CHCRH:/var/lib/do'
-(0) 18:26:34 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
-(0) 18:26:34 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-67-ga8e5025
-(0) 18:26:34 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
-(0) 18:26:34 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "FLUID"
+Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/5ISINEBOUTXVJHXU2ANYU6T5QR:/var/lib/docker/overlay2/l/S7JPOC43YIUH4QCV22B2K3ESKN:/var/lib/docker/overlay2/l/TSCYI2HUGXOWGM5ZBSDTQL6DTI:/var/lib/docker/overlay2/l/7MMR5MWJPM2NEAUXPSJP6JMEUB:/var/lib/docker/overlay2/l/4C6XDPKRUHVXULYWQP7OZTDYJN:/var/lib/docker/overlay2/l/5OGQDAZTJS24IIY33CAIDUHWPU:/var/lib/docker/overlay2/l/ZPV5WYBIGJ5DH26P67AH2JINRS:/var/lib/docker/overlay2/l/WIODWQ3UP55D5N3D4T2VNBHBDI:/var/lib/docker/overlay2/l/TGMKUAGKBQLSE'
+Unexpected end of /proc/mounts line `JLQDYT25ZDG3D:/var/lib/docker/overlay2/l/JS7OJFYLSJRXLAIHCVUPWKA65B:/var/lib/docker/overlay2/l/IWJPVPY2RLKGRCIEGUP3NM5XVJ:/var/lib/docker/overlay2/l/NQOMFA67K6XH5BPTOXF7B3YZ2O:/var/lib/docker/overlay2/l/HDOAVBF756CG3D5KKSOM2X4RUT:/var/lib/docker/overlay2/l/W2RE43VU27XWVLZ26OMJC4OQME:/var/lib/docker/overlay2/l/7FT267WYAU7E3YF4TRQ7P6WQBX:/var/lib/docker/overlay2/l/VEPYF3PIVMZXTIZLNT6RF6E6KP:/var/lib/docker/overlay2/l/AVQIJWLHAXG4KI3D25NHAMDPKR:/var/lib/docker/overlay2/l/GXWBN4A74IQWBVZWSGX5PEB2ER:/var/lib/do'
+(0) 16:22:15 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
+(0) 16:22:15 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-72-g657f759
+(0) 16:22:15 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
+(0) 16:22:15 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "FLUID"
 Initialize preCICE...
-(0) 18:26:34 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
-(0) 18:26:34 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
-(0) 18:26:34 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
-(0) 18:26:34 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Fluid_Nodes
-(0) 18:26:34 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Fluid_Nodes
-(0) 18:26:34 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Fluid_Nodes
-(0) 18:26:34 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Structure_Nodes
-(0) 18:26:34 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
-(0) 18:26:34 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
-(0) 18:26:34 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 
-(0) 18:26:34 [impl::SolverInterfaceImpl]:1305 in mapReadData: [0mCompute read mapping from mesh "Structure_Nodes" to mesh "Fluid_Nodes".
-(0) 18:26:34 [mapping::NearestNeighborMapping]:57 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
+(0) 16:22:15 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
+(0) 16:22:15 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
+(0) 16:22:15 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
+(0) 16:22:15 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Fluid_Nodes
+(0) 16:22:15 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Fluid_Nodes
+(0) 16:22:15 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Fluid_Nodes
+(0) 16:22:15 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Structure_Nodes
+(0) 16:22:15 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
+(0) 16:22:15 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
+(0) 16:22:15 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:1309 in mapReadData: [0mCompute read mapping from mesh "Structure_Nodes" to mesh "Fluid_Nodes".
+(0) 16:22:15 [mapping::NearestNeighborMapping]:57 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
 Nonlinear Solver break, iterations: 3, residual norm: 4.402046e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 9, residual norm: 2.563189e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 6.664613e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 5.658223e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 6.911183e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.010000 to Postproc/out_fluid_0.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.371232e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 6.082325e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 4.522278e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 6.494819e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.020000 to Postproc/out_fluid_1.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 8.126967e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 8.621306e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 2.249507e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.030000 to Postproc/out_fluid_2.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 5.190631e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 3.331966e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 8.673974e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.040000 to Postproc/out_fluid_3.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.815040e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 8.204532e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 8.292406e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.050000 to Postproc/out_fluid_4.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.199010e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.313388e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 4.787513e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.060000 to Postproc/out_fluid_5.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.348037e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 7.735208e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 1.899324e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.070000 to Postproc/out_fluid_6.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.044740e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.049573e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 2.148617e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.080000 to Postproc/out_fluid_7.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.266416e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.739466e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 8.918976e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.090000 to Postproc/out_fluid_8.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.599461e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 9.213299e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 4.672529e-16
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.100000 to Postproc/out_fluid_9.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.892832e-16
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.216543e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 4.110248e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.110000 to Postproc/out_fluid_10.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 2.334559e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.000319e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 4.959414e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.120000 to Postproc/out_fluid_11.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.677526e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 7.933885e-17
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 4.129038e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.130000 to Postproc/out_fluid_12.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.256574e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.885140e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 1.429077e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.140000 to Postproc/out_fluid_13.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.492377e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.169413e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 2.253117e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.150000 to Postproc/out_fluid_14.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.505335e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.712705e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 8.244031e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.160000 to Postproc/out_fluid_15.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.629218e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 4.764702e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 3.142286e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.170000 to Postproc/out_fluid_16.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 9.157290e-17
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 3.590374e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 3.580278e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.180000 to Postproc/out_fluid_17.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 4.167657e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 8.013323e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 2.530433e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.190000 to Postproc/out_fluid_18.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 3.188343e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 8.764682e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 7.488897e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.200000 to Postproc/out_fluid_19.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.074233e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 6.034810e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 1.943538e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.210000 to Postproc/out_fluid_20.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 4.228783e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 3.531604e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 3.118924e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.220000 to Postproc/out_fluid_21.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 3.390008e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 4.936364e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.941000e-16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.230000 to Postproc/out_fluid_22.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 1.928230e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 9, residual norm: 5.914393e-16
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 4.842653e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.240000 to Postproc/out_fluid_23.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 6.769190e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 3.994010e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 7.606055e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.250000 to Postproc/out_fluid_24.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 1.117588e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 9.334783e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 6.086785e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.260000 to Postproc/out_fluid_25.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 7.423720e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 3.882952e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 2.423846e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.270000 to Postproc/out_fluid_26.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 4.104761e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 5.170012e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 1.188175e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.280000 to Postproc/out_fluid_27.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.985072e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 6.043470e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 8.416012e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.290000 to Postproc/out_fluid_28.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 9.774120e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 5.241370e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 5.676042e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.300000 to Postproc/out_fluid_29.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 8.440182e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.053303e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 4.439314e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.310000 to Postproc/out_fluid_30.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 1.824168e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 8.120601e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 2.342247e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.320000 to Postproc/out_fluid_31.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.537169e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.057098e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.389812e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.330000 to Postproc/out_fluid_32.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.560942e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.084427e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.307980e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.340000 to Postproc/out_fluid_33.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.661950e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.823119e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.526147e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.350000 to Postproc/out_fluid_34.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.837564e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.821446e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 1.517599e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.360000 to Postproc/out_fluid_35.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.129239e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 6.272737e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.570116e-16
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.370000 to Postproc/out_fluid_36.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.115121e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.501679e-16
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.142790e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.380000 to Postproc/out_fluid_37.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 2.682063e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 5.686452e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 4.848708e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.390000 to Postproc/out_fluid_38.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.569233e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.453382e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 7.517226e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.400000 to Postproc/out_fluid_39.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.099385e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.716557e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 4.294989e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.410000 to Postproc/out_fluid_40.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.109100e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.337738e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 9.192349e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.420000 to Postproc/out_fluid_41.vtk
 Nonlinear Solver break, iterations: 14, residual norm: 1.458794e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.207862e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 3.767327e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.430000 to Postproc/out_fluid_42.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.737501e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 3.253141e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 1.340472e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.440000 to Postproc/out_fluid_43.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.800021e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.526485e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 3.900863e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.450000 to Postproc/out_fluid_44.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.721518e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.533551e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 5.051352e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.460000 to Postproc/out_fluid_45.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.629254e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.183867e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 2.176019e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.470000 to Postproc/out_fluid_46.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.255832e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.015942e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 9.873260e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.480000 to Postproc/out_fluid_47.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.004968e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.283013e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 3.232214e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.490000 to Postproc/out_fluid_48.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.084364e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.670820e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.395150e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.500000 to Postproc/out_fluid_49.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.336332e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.115654e-16
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 9.331984e-16
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.510000 to Postproc/out_fluid_50.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.694161e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.474691e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 1.304050e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.520000 to Postproc/out_fluid_51.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.428160e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.445459e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 4.063887e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.530000 to Postproc/out_fluid_52.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.238267e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.322353e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 2.916357e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.540000 to Postproc/out_fluid_53.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.517958e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 3.065923e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 4.627531e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.550000 to Postproc/out_fluid_54.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.421625e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 3.066266e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 3.741284e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.560000 to Postproc/out_fluid_55.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.607263e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.681113e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 8.011235e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.570000 to Postproc/out_fluid_56.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.272677e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.671943e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 8.606975e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.580000 to Postproc/out_fluid_57.vtk
 Nonlinear Solver break, iterations: 14, residual norm: 1.523055e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 9.147896e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 2.231332e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.590000 to Postproc/out_fluid_58.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.212804e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 5.139155e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.535430e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.600000 to Postproc/out_fluid_59.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 9.686223e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.593514e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.987707e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.610000 to Postproc/out_fluid_60.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.706328e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.383498e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 7.120717e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.620000 to Postproc/out_fluid_61.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 2.507549e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.637211e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 2.911279e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.630000 to Postproc/out_fluid_62.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.994783e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.479899e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 4.666130e-16
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.640000 to Postproc/out_fluid_63.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.633439e-16
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.787031e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 2.446862e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.650000 to Postproc/out_fluid_64.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.354147e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.545819e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 6.543339e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.660000 to Postproc/out_fluid_65.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.157178e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 8.701007e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 8.008883e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.670000 to Postproc/out_fluid_66.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.671992e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.590561e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.049711e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.680000 to Postproc/out_fluid_67.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 7.632976e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 5.455093e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 7.575083e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.690000 to Postproc/out_fluid_68.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 1.492238e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 8.430530e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 4.209711e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.700000 to Postproc/out_fluid_69.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.218488e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 4.528376e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.750139e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.710000 to Postproc/out_fluid_70.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.410535e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 3.009544e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 4.039760e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.720000 to Postproc/out_fluid_71.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 5.111108e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 2.645238e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 6.631446e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.730000 to Postproc/out_fluid_72.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 2.828577e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 9, residual norm: 4.603044e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 9.996693e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.740000 to Postproc/out_fluid_73.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 8.826207e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 7.793178e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 9.038260e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.750000 to Postproc/out_fluid_74.vtk
 Nonlinear Solver break, iterations: 9, residual norm: 4.236390e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 9.516688e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 8.739496e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.760000 to Postproc/out_fluid_75.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 7.241442e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 2.594421e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 5.112743e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.770000 to Postproc/out_fluid_76.vtk
 Nonlinear Solver break, iterations: 10, residual norm: 4.722825e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 10, residual norm: 7.224952e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 8.906160e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.780000 to Postproc/out_fluid_77.vtk
 Nonlinear Solver break, iterations: 12, residual norm: 4.139800e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 6.344916e-16
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 2.790545e-16
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.790000 to Postproc/out_fluid_78.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.192880e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 6.493632e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 2.700220e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.800000 to Postproc/out_fluid_79.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.230078e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 1.737337e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 5.890064e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.810000 to Postproc/out_fluid_80.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 2.691558e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 12, residual norm: 9.203846e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 3.735401e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.820000 to Postproc/out_fluid_81.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 4.304208e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.346961e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 8.738887e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.830000 to Postproc/out_fluid_82.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 8.819589e-17
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.627388e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 1.868733e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.840000 to Postproc/out_fluid_83.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.011504e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.192552e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 3, residual norm: 5.668943e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.850000 to Postproc/out_fluid_84.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.043120e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.571999e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 3.323499e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.860000 to Postproc/out_fluid_85.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.868144e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.653504e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 6.679028e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.870000 to Postproc/out_fluid_86.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.845973e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 5.954942e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 5.365619e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.880000 to Postproc/out_fluid_87.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 5.699775e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 2.436042e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 4, residual norm: 9.856050e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.890000 to Postproc/out_fluid_88.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 2.887590e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 3.173631e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 7.926196e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.900000 to Postproc/out_fluid_89.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 3.614479e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 11, residual norm: 6.518027e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 7.695490e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.910000 to Postproc/out_fluid_90.vtk
 Nonlinear Solver break, iterations: 11, residual norm: 7.505324e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.831185e-16
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 1.363098e-16
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.920000 to Postproc/out_fluid_91.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.342884e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.110524e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 9.369103e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.930000 to Postproc/out_fluid_92.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.086554e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.049071e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 5.007207e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.940000 to Postproc/out_fluid_93.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.137278e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.718015e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 4.912879e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.950000 to Postproc/out_fluid_94.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.780354e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.132557e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 9.931774e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.960000 to Postproc/out_fluid_95.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 2.562960e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.390683e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 5, residual norm: 8.398380e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.970000 to Postproc/out_fluid_96.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.967298e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 1.056001e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 8, residual norm: 1.317752e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.980000 to Postproc/out_fluid_97.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 3.021018e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.199865e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 7, residual norm: 1.698108e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 writing timestep at t=0.990000 to Postproc/out_fluid_98.vtk
 Nonlinear Solver break, iterations: 13, residual norm: 1.752616e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 13, residual norm: 2.005538e-16
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Nonlinear Solver break, iterations: 6, residual norm: 7.969055e-16
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
 writing timestep at t=1.000000 to Postproc/out_fluid_99.vtk

--- a/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/referenceOutput/Structure.log
+++ b/tests/TestCompose_1dtube_cxx.Ubuntu1604.home/referenceOutput/Structure.log
@@ -1,1534 +1,1534 @@
 Starting Structure Solver...
 N: 100
-Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/4SC56LF3HVRK544D6UBZC2VBF6:/var/lib/docker/overlay2/l/VELHVVSTWHP5PBCXW6ISXV54YF:/var/lib/docker/overlay2/l/FZCZPUYFHFHJHYYLRJDQVDN3Y4:/var/lib/docker/overlay2/l/R6CDUM3R4BRL72OF7HM4OE4ZKZ:/var/lib/docker/overlay2/l/TTGFLT2GQJRTXXX42Q7LKLX5V4:/var/lib/docker/overlay2/l/Q763VSE3LEMXV2IOPOU3O2LJRX:/var/lib/docker/overlay2/l/MOOWAB7TLKH6MGFYQXXILS3FKE:/var/lib/docker/overlay2/l/44LBYLVBBUNNFAUP5RUDWQCMLN:/var/lib/docker/overlay2/l/STLE4NK37NAAP'
-Unexpected end of /proc/mounts line `KWBJEUVNYRRQ2:/var/lib/docker/overlay2/l/VEX7AUYLW52VRXP763KYUWBM6J:/var/lib/docker/overlay2/l/B4AAZBCUXFFVZFMYOJSTC7XDMD:/var/lib/docker/overlay2/l/4GB57N2RV75GNIJZ7Z2FPRTI5D:/var/lib/docker/overlay2/l/PENZ6SRQSXINRZJWII25STOKZS:/var/lib/docker/overlay2/l/J6UFTARNBX7TRO7DCKQKQJMMYK:/var/lib/docker/overlay2/l/GA74WG2GHI7X5PD7AINOBA35U3:/var/lib/docker/overlay2/l/B4TDE74BCCFM2AEZ5EDTK3LGB5:/var/lib/docker/overlay2/l/F6KSORICGXNQPFZ47NCBR3SQHG:/var/lib/docker/overlay2/l/FKBOMOD2SES4HBT77IA42CHCRH:/var/lib/do'
-(0) 18:26:34 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
-(0) 18:26:34 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-67-ga8e5025
-(0) 18:26:34 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
-(0) 18:26:34 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "STRUCTURE"
+Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/5ISINEBOUTXVJHXU2ANYU6T5QR:/var/lib/docker/overlay2/l/S7JPOC43YIUH4QCV22B2K3ESKN:/var/lib/docker/overlay2/l/TSCYI2HUGXOWGM5ZBSDTQL6DTI:/var/lib/docker/overlay2/l/7MMR5MWJPM2NEAUXPSJP6JMEUB:/var/lib/docker/overlay2/l/4C6XDPKRUHVXULYWQP7OZTDYJN:/var/lib/docker/overlay2/l/5OGQDAZTJS24IIY33CAIDUHWPU:/var/lib/docker/overlay2/l/ZPV5WYBIGJ5DH26P67AH2JINRS:/var/lib/docker/overlay2/l/WIODWQ3UP55D5N3D4T2VNBHBDI:/var/lib/docker/overlay2/l/TGMKUAGKBQLSE'
+Unexpected end of /proc/mounts line `JLQDYT25ZDG3D:/var/lib/docker/overlay2/l/JS7OJFYLSJRXLAIHCVUPWKA65B:/var/lib/docker/overlay2/l/IWJPVPY2RLKGRCIEGUP3NM5XVJ:/var/lib/docker/overlay2/l/NQOMFA67K6XH5BPTOXF7B3YZ2O:/var/lib/docker/overlay2/l/HDOAVBF756CG3D5KKSOM2X4RUT:/var/lib/docker/overlay2/l/W2RE43VU27XWVLZ26OMJC4OQME:/var/lib/docker/overlay2/l/7FT267WYAU7E3YF4TRQ7P6WQBX:/var/lib/docker/overlay2/l/VEPYF3PIVMZXTIZLNT6RF6E6KP:/var/lib/docker/overlay2/l/AVQIJWLHAXG4KI3D25NHAMDPKR:/var/lib/docker/overlay2/l/GXWBN4A74IQWBVZWSGX5PEB2ER:/var/lib/do'
+(0) 16:22:15 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
+(0) 16:22:15 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-72-g657f759
+(0) 16:22:15 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
+(0) 16:22:15 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "STRUCTURE"
 preCICE configured...
 Structure: init precice...
-(0) 18:26:34 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
-(0) 18:26:34 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
-(0) 18:26:34 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
-(0) 18:26:34 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Fluid_Nodes
-(0) 18:26:34 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Structure_Nodes
-(0) 18:26:34 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Structure_Nodes
-(0) 18:26:34 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Structure_Nodes
-(0) 18:26:34 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
-(0) 18:26:34 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
-(0) 18:26:34 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-initial-data | write-iteration-checkpoint | 
-(0) 18:26:34 [impl::SolverInterfaceImpl]:1305 in mapReadData: [0mCompute read mapping from mesh "Fluid_Nodes" to mesh "Structure_Nodes".
-(0) 18:26:34 [mapping::NearestNeighborMapping]:57 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.51517e-06, relative limit = 1.51517e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.51517e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
+(0) 16:22:15 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
+(0) 16:22:15 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
+(0) 16:22:15 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Fluid_Nodes
+(0) 16:22:15 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Structure_Nodes
+(0) 16:22:15 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Structure_Nodes
+(0) 16:22:15 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Structure_Nodes
+(0) 16:22:15 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
+(0) 16:22:15 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
+(0) 16:22:15 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-initial-data | write-iteration-checkpoint | 
+(0) 16:22:15 [impl::SolverInterfaceImpl]:1309 in mapReadData: [0mCompute read mapping from mesh "Fluid_Nodes" to mesh "Structure_Nodes".
+(0) 16:22:15 [mapping::NearestNeighborMapping]:57 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.51517e-06, relative limit = 1.51517e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.51517e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38762e-08, relative limit = 1.50133e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.48618e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38762e-08, relative limit = 1.50133e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.48618e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.08245e-07, relative limit = 7.9623e-12, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.60115e-09, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.08245e-07, relative limit = 7.9623e-12, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.60115e-09, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08565e-09, relative limit = 7.95186e-12, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47103e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08565e-09, relative limit = 7.95186e-12, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47103e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.37324e-13, relative limit = 7.95186e-12, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.99082e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:239 in extrapolateData: [0mPerforming first order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.37324e-13, relative limit = 7.95186e-12, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.99082e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:266 in extrapolateData: [0mPerforming first order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 1
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.71126e-06, relative limit = 5.50318e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.92067e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.71126e-06, relative limit = 5.50318e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.92067e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87669e-06, relative limit = 3.63048e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.80445e-10, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87669e-06, relative limit = 3.63048e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.80445e-10, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54431e-11, relative limit = 3.6304e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.18093e-13, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54431e-11, relative limit = 3.6304e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.18093e-13, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 40 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.71878e-14, relative limit = 3.6304e-11, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.14803e-15, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.71878e-14, relative limit = 3.6304e-11, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.14803e-15, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 2
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.77834e-06, relative limit = 1.14011e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93112e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.77834e-06, relative limit = 1.14011e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93112e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87989e-06, relative limit = 9.52269e-11, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22746e-10, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87989e-06, relative limit = 9.52269e-11, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22746e-10, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.868e-11, relative limit = 9.52263e-11, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75577e-12, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.868e-11, relative limit = 9.52263e-11, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75577e-12, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 3
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.73079e-06, relative limit = 1.92434e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.30735e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.73079e-06, relative limit = 1.92434e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.30735e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09752e-06, relative limit = 1.81462e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.57423e-10, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09752e-06, relative limit = 1.81462e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.57423e-10, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67408e-10, relative limit = 1.81461e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.2454e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67408e-10, relative limit = 1.81461e-10, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.2454e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 4
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0924e-05, relative limit = 2.90588e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.27538e-07, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0924e-05, relative limit = 2.90588e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.27538e-07, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36555e-07, relative limit = 2.86224e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.9881e-13, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36555e-07, relative limit = 2.86224e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.9881e-13, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76257e-13, relative limit = 2.86224e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.31133e-15, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76257e-13, relative limit = 2.86224e-10, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.31133e-15, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 5
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21584e-05, relative limit = 4.07703e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.41817e-07, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21584e-05, relative limit = 4.07703e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.41817e-07, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.52879e-07, relative limit = 4.04177e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.53772e-12, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.52879e-07, relative limit = 4.04177e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.53772e-12, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61989e-12, relative limit = 4.04177e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70469e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61989e-12, relative limit = 4.04177e-10, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70469e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 6
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38694e-05, relative limit = 5.42795e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40442e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38694e-05, relative limit = 5.42795e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40442e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.71907e-07, relative limit = 5.36086e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34777e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.71907e-07, relative limit = 5.36086e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34777e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.40059e-12, relative limit = 5.36086e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.51083e-15, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.40059e-12, relative limit = 5.36086e-10, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.51083e-15, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 7
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59178e-05, relative limit = 6.95214e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02319e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59178e-05, relative limit = 6.95214e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02319e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.67944e-07, relative limit = 6.85552e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06325e-12, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.67944e-07, relative limit = 6.85552e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06325e-12, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.6932e-13, relative limit = 6.85552e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.37377e-15, relative limit = 0.000100499, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.6932e-13, relative limit = 6.85552e-10, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.37377e-15, relative limit = 0.000100499, conv = true
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 8
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79057e-05, relative limit = 8.64568e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.07657e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79057e-05, relative limit = 8.64568e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.07657e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.92638e-07, relative limit = 8.54662e-10, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.50168e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.92638e-07, relative limit = 8.54662e-10, conv = false
+(0) 16:22:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.50168e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.12378e-12, relative limit = 8.54662e-10, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.20137e-15, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.12378e-12, relative limit = 8.54662e-10, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.20137e-15, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 9
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95815e-05, relative limit = 1.05043e-09, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.6834e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95815e-05, relative limit = 1.05043e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.6834e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.03487e-07, relative limit = 1.04242e-09, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.57925e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.03487e-07, relative limit = 1.04242e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.57925e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.97023e-12, relative limit = 1.04242e-09, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27827e-14, relative limit = 0.0001005, conv = true
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.97023e-12, relative limit = 1.04242e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27827e-14, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 10
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09788e-05, relative limit = 1.25216e-09, conv = false
-(0) 18:26:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26552e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09788e-05, relative limit = 1.25216e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26552e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.03294e-07, relative limit = 1.24614e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.84176e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.03294e-07, relative limit = 1.24614e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.84176e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.81472e-12, relative limit = 1.24614e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43273e-15, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.81472e-12, relative limit = 1.24614e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43273e-15, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 11
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22763e-05, relative limit = 1.46885e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10006e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22763e-05, relative limit = 1.46885e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10006e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.24815e-07, relative limit = 1.46362e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88834e-11, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.24815e-07, relative limit = 1.46362e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88834e-11, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9147e-12, relative limit = 1.46362e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.42978e-15, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9147e-12, relative limit = 1.46362e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.42978e-15, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 12
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35971e-05, relative limit = 1.69954e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.15587e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35971e-05, relative limit = 1.69954e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.15587e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.52133e-07, relative limit = 1.69403e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55373e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.52133e-07, relative limit = 1.69403e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55373e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76933e-12, relative limit = 1.69403e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.16864e-14, relative limit = 0.0001005, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76933e-12, relative limit = 1.69403e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.16864e-14, relative limit = 0.0001005, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 13
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49277e-05, relative limit = 1.94327e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23411e-06, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49277e-05, relative limit = 1.94327e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23411e-06, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.8969e-07, relative limit = 1.93739e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32723e-12, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.8969e-07, relative limit = 1.93739e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32723e-12, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.13184e-13, relative limit = 1.93739e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.31981e-15, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.13184e-13, relative limit = 1.93739e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.31981e-15, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 14
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61764e-05, relative limit = 2.19911e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18956e-06, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61764e-05, relative limit = 2.19911e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18956e-06, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68163e-07, relative limit = 2.19345e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.91356e-12, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68163e-07, relative limit = 2.19345e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.91356e-12, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.43859e-13, relative limit = 2.19345e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89925e-13, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.43859e-13, relative limit = 2.19345e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89925e-13, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 15
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72717e-05, relative limit = 2.46613e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02588e-06, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72717e-05, relative limit = 2.46613e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02588e-06, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.89586e-07, relative limit = 2.46125e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.85973e-12, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.89586e-07, relative limit = 2.46125e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.85973e-12, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65788e-13, relative limit = 2.46125e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.26433e-14, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65788e-13, relative limit = 2.46125e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.26433e-14, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 16
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82076e-05, relative limit = 2.74328e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.36411e-07, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82076e-05, relative limit = 2.74328e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.36411e-07, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.98849e-07, relative limit = 2.73931e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.71771e-12, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.98849e-07, relative limit = 2.73931e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.71771e-12, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18003e-12, relative limit = 2.73931e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76515e-14, relative limit = 0.000100501, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18003e-12, relative limit = 2.73931e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76515e-14, relative limit = 0.000100501, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 17
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90203e-05, relative limit = 3.02947e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.96619e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90203e-05, relative limit = 3.02947e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.96619e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32126e-07, relative limit = 3.02616e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06773e-11, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32126e-07, relative limit = 3.02616e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06773e-11, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.41192e-12, relative limit = 3.02616e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.57199e-14, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.41192e-12, relative limit = 3.02616e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.57199e-14, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 18
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9741e-05, relative limit = 3.32353e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.11625e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9741e-05, relative limit = 3.32353e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.11625e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9166e-07, relative limit = 3.32062e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.37086e-13, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9166e-07, relative limit = 3.32062e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.37086e-13, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14893e-13, relative limit = 3.32062e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47258e-15, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14893e-13, relative limit = 3.32062e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47258e-15, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 19
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03703e-05, relative limit = 3.62428e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.39091e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03703e-05, relative limit = 3.62428e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.39091e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.57054e-07, relative limit = 3.62172e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.41802e-13, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.57054e-07, relative limit = 3.62172e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.41802e-13, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.07519e-13, relative limit = 3.62172e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56915e-14, relative limit = 0.000100502, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.07519e-13, relative limit = 3.62172e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56915e-14, relative limit = 0.000100502, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 20
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.08874e-05, relative limit = 3.93055e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.41024e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.08874e-05, relative limit = 3.93055e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.41024e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10101e-07, relative limit = 3.92846e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34553e-12, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10101e-07, relative limit = 3.92846e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34553e-12, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.09169e-13, relative limit = 3.92846e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.77476e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.09169e-13, relative limit = 3.92846e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.77476e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 21
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1273e-05, relative limit = 4.24115e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12655e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1273e-05, relative limit = 4.24115e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12655e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.48556e-07, relative limit = 4.23967e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59016e-13, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.48556e-07, relative limit = 4.23967e-09, conv = false
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59016e-13, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.7249e-14, relative limit = 4.23967e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.42989e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.7249e-14, relative limit = 4.23967e-09, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.42989e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:16 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 22
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15223e-05, relative limit = 4.55485e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74176e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15223e-05, relative limit = 4.55485e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74176e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.20478e-08, relative limit = 4.55403e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.39729e-13, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.20478e-08, relative limit = 4.55403e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.39729e-13, relative limit = 0.000100503, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.57999e-13, relative limit = 4.55403e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10632e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.57999e-13, relative limit = 4.55403e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10632e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 23
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16427e-05, relative limit = 4.87041e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.78715e-08, relative limit = 0.000100504, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16427e-05, relative limit = 4.87041e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.78715e-08, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01537e-08, relative limit = 4.87021e-09, conv = false
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.15081e-12, relative limit = 0.000100504, conv = true
-(0) 18:26:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01537e-08, relative limit = 4.87021e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.15081e-12, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15982e-13, relative limit = 4.87021e-09, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.63802e-14, relative limit = 0.000100504, conv = true
-(0) 18:26:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15982e-13, relative limit = 4.87021e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.63802e-14, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 24
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16424e-05, relative limit = 5.18658e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47342e-08, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16424e-05, relative limit = 5.18658e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47342e-08, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.50837e-08, relative limit = 5.18693e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.65477e-12, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.50837e-08, relative limit = 5.18693e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.65477e-12, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.67418e-13, relative limit = 5.18693e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43713e-14, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.67418e-13, relative limit = 5.18693e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43713e-14, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 25
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15236e-05, relative limit = 5.50212e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82987e-07, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15236e-05, relative limit = 5.50212e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82987e-07, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.75391e-08, relative limit = 5.50299e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51162e-12, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.75391e-08, relative limit = 5.50299e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51162e-12, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.05396e-12, relative limit = 5.50299e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08914e-13, relative limit = 0.000100504, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.05396e-12, relative limit = 5.50299e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08914e-13, relative limit = 0.000100504, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 26
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12831e-05, relative limit = 5.81577e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9604e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12831e-05, relative limit = 5.81577e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9604e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.41733e-07, relative limit = 5.81718e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83957e-12, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.41733e-07, relative limit = 5.81718e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83957e-12, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.29774e-13, relative limit = 5.81718e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38097e-14, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.29774e-13, relative limit = 5.81718e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38097e-14, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 27
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09175e-05, relative limit = 6.1263e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15095e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09175e-05, relative limit = 6.1263e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15095e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98707e-07, relative limit = 6.12828e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.59204e-13, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98707e-07, relative limit = 6.12828e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.59204e-13, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.42556e-13, relative limit = 6.12828e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.51679e-15, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.42556e-13, relative limit = 6.12828e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.51679e-15, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 28
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04269e-05, relative limit = 6.43249e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.35679e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04269e-05, relative limit = 6.43249e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.35679e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.56375e-07, relative limit = 6.43504e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15962e-13, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.56375e-07, relative limit = 6.43504e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15962e-13, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.51024e-14, relative limit = 6.43504e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09476e-15, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.51024e-14, relative limit = 6.43504e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09476e-15, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 29
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98147e-05, relative limit = 6.73313e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.52426e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98147e-05, relative limit = 6.73313e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.52426e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12186e-07, relative limit = 6.73623e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00619e-12, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12186e-07, relative limit = 6.73623e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00619e-12, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.06798e-13, relative limit = 6.73623e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32596e-14, relative limit = 0.000100505, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.06798e-13, relative limit = 6.73623e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32596e-14, relative limit = 0.000100505, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 30
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90857e-05, relative limit = 7.02703e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.63238e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90857e-05, relative limit = 7.02703e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.63238e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.65143e-07, relative limit = 7.03066e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59637e-12, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.65143e-07, relative limit = 7.03066e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59637e-12, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.40971e-13, relative limit = 7.03066e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.53372e-14, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.40971e-13, relative limit = 7.03066e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.53372e-14, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 31
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82434e-05, relative limit = 7.31303e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.69335e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82434e-05, relative limit = 7.31303e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.69335e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15839e-07, relative limit = 7.31717e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.82143e-13, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15839e-07, relative limit = 7.31717e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.82143e-13, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.74961e-13, relative limit = 7.31717e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07674e-15, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.74961e-13, relative limit = 7.31717e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07674e-15, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 32
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72905e-05, relative limit = 7.59e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.72689e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72905e-05, relative limit = 7.59e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.72689e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65223e-07, relative limit = 7.59463e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23022e-12, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65223e-07, relative limit = 7.59463e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23022e-12, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.81747e-13, relative limit = 7.59463e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55583e-14, relative limit = 0.000100506, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.81747e-13, relative limit = 7.59463e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55583e-14, relative limit = 0.000100506, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 33
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.62298e-05, relative limit = 7.85686e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.07384e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.62298e-05, relative limit = 7.85686e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.07384e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.13553e-07, relative limit = 7.86196e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.8496e-13, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.13553e-07, relative limit = 7.86196e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.8496e-13, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82746e-13, relative limit = 7.86196e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72871e-14, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82746e-13, relative limit = 7.86196e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72871e-14, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 34
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.50649e-05, relative limit = 8.11253e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17169e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.50649e-05, relative limit = 8.11253e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17169e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.60301e-07, relative limit = 8.1181e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.78478e-13, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.60301e-07, relative limit = 8.1181e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.78478e-13, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43851e-13, relative limit = 8.1181e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89598e-14, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43851e-13, relative limit = 8.1181e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89598e-14, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 35
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38009e-05, relative limit = 8.35603e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26468e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38009e-05, relative limit = 8.35603e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26468e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.04722e-07, relative limit = 8.36204e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46893e-13, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.04722e-07, relative limit = 8.36204e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46893e-13, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.69372e-13, relative limit = 8.36204e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9997e-15, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.69372e-13, relative limit = 8.36204e-09, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9997e-15, relative limit = 0.000100507, conv = true
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 36
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24431e-05, relative limit = 8.58638e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35191e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24431e-05, relative limit = 8.58638e-09, conv = false
+(0) 16:22:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35191e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46383e-07, relative limit = 8.59281e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43403e-13, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46383e-07, relative limit = 8.59281e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43403e-13, relative limit = 0.000100507, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24793e-13, relative limit = 8.59281e-09, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33227e-15, relative limit = 0.000100507, conv = true
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24793e-13, relative limit = 8.59281e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33227e-15, relative limit = 0.000100507, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 37
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09972e-05, relative limit = 8.80268e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.4333e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09972e-05, relative limit = 8.80268e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.4333e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85256e-07, relative limit = 8.80949e-09, conv = false
-(0) 18:26:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.0488e-13, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85256e-07, relative limit = 8.80949e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.0488e-13, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.59963e-14, relative limit = 8.80949e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38667e-15, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.59963e-14, relative limit = 8.80949e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.38667e-15, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 38
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94689e-05, relative limit = 9.00408e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50911e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94689e-05, relative limit = 9.00408e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50911e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21446e-07, relative limit = 9.01125e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81565e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21446e-07, relative limit = 9.01125e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81565e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32833e-11, relative limit = 9.01125e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6894e-13, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32833e-11, relative limit = 9.01125e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6894e-13, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 39
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.7864e-05, relative limit = 9.18977e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57934e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.7864e-05, relative limit = 9.18977e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57934e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54978e-07, relative limit = 9.19727e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.60549e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54978e-07, relative limit = 9.19727e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.60549e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26042e-11, relative limit = 9.19727e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00265e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26042e-11, relative limit = 9.19727e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00265e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 40
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61888e-05, relative limit = 9.35903e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64359e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61888e-05, relative limit = 9.35903e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64359e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.85655e-07, relative limit = 9.36684e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81002e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.85655e-07, relative limit = 9.36684e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81002e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33057e-11, relative limit = 9.36684e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.28137e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33057e-11, relative limit = 9.36684e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.28137e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 41
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.445e-05, relative limit = 9.51119e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70135e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.445e-05, relative limit = 9.51119e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70135e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.13225e-07, relative limit = 9.51927e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.8786e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.13225e-07, relative limit = 9.51927e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.8786e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37833e-11, relative limit = 9.51927e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02694e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37833e-11, relative limit = 9.51927e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02694e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 42
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26548e-05, relative limit = 9.64564e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75222e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26548e-05, relative limit = 9.64564e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75222e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37504e-07, relative limit = 9.65397e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.34104e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37504e-07, relative limit = 9.65397e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.34104e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14986e-11, relative limit = 9.65397e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.68814e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14986e-11, relative limit = 9.65397e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.68814e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 43
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08106e-05, relative limit = 9.76187e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79603e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08106e-05, relative limit = 9.76187e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79603e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.5841e-07, relative limit = 9.7704e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.61151e-11, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.5841e-07, relative limit = 9.7704e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.61151e-11, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2755e-11, relative limit = 9.7704e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02085e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2755e-11, relative limit = 9.7704e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02085e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 44
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.92534e-06, relative limit = 9.8594e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83276e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.92534e-06, relative limit = 9.8594e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83276e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.75925e-07, relative limit = 9.8681e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.66264e-11, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.75925e-07, relative limit = 9.8681e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.66264e-11, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34265e-11, relative limit = 9.8681e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32875e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34265e-11, relative limit = 9.8681e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32875e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 45
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.00756e-06, relative limit = 9.93785e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86233e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.00756e-06, relative limit = 9.93785e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86233e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.9002e-07, relative limit = 9.9467e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.33371e-11, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.9002e-07, relative limit = 9.9467e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.33371e-11, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56839e-11, relative limit = 9.9467e-09, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26181e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56839e-11, relative limit = 9.9467e-09, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26181e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 46
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.06785e-06, relative limit = 9.99692e-09, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88462e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.06785e-06, relative limit = 9.99692e-09, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88462e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00624e-07, relative limit = 1.00059e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.3689e-11, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00624e-07, relative limit = 1.00059e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.3689e-11, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90677e-11, relative limit = 1.00059e-08, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.20862e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90677e-11, relative limit = 1.00059e-08, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.20862e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 47
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12461e-06, relative limit = 1.00364e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89948e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12461e-06, relative limit = 1.00364e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89948e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07719e-07, relative limit = 1.00454e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.68392e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07719e-07, relative limit = 1.00454e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.68392e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.91084e-13, relative limit = 1.00454e-08, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.29766e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.91084e-13, relative limit = 1.00454e-08, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.29766e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 48
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26387e-06, relative limit = 1.00561e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.9068e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26387e-06, relative limit = 1.00561e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.9068e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11181e-07, relative limit = 1.00651e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.1814e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11181e-07, relative limit = 1.00651e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.1814e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66819e-12, relative limit = 1.00651e-08, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.80103e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66819e-12, relative limit = 1.00651e-08, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.80103e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 49
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14662e-06, relative limit = 1.00559e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90656e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14662e-06, relative limit = 1.00559e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90656e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11034e-07, relative limit = 1.00649e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.96582e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11034e-07, relative limit = 1.00649e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.96582e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27744e-13, relative limit = 1.00649e-08, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06799e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27744e-13, relative limit = 1.00649e-08, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06799e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 50
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98654e-06, relative limit = 1.00358e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89879e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98654e-06, relative limit = 1.00358e-08, conv = false
+(0) 16:22:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89879e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07282e-07, relative limit = 1.00449e-08, conv = false
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.42527e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07282e-07, relative limit = 1.00449e-08, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.42527e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6499e-12, relative limit = 1.00449e-08, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.62756e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:37 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6499e-12, relative limit = 1.00449e-08, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.62756e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 51
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.92863e-06, relative limit = 9.99605e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88355e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.92863e-06, relative limit = 9.99605e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88355e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.99961e-07, relative limit = 1.0005e-08, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.74948e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.99961e-07, relative limit = 1.0005e-08, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.74948e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.84493e-12, relative limit = 1.0005e-08, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.9413e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.84493e-12, relative limit = 1.0005e-08, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.9413e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 52
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.86937e-06, relative limit = 9.93663e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86088e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.86937e-06, relative limit = 9.93663e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86088e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.89099e-07, relative limit = 9.94546e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66017e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.89099e-07, relative limit = 9.94546e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66017e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07119e-13, relative limit = 9.94546e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65896e-14, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07119e-13, relative limit = 9.94546e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65896e-14, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 53
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.78915e-06, relative limit = 9.85783e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83088e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.78915e-06, relative limit = 9.85783e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83088e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.74727e-07, relative limit = 9.86652e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35023e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.74727e-07, relative limit = 9.86652e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35023e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.90329e-13, relative limit = 9.86652e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.21885e-15, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.90329e-13, relative limit = 9.86652e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.21885e-15, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 54
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06771e-05, relative limit = 9.75997e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79364e-06, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06771e-05, relative limit = 9.75997e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79364e-06, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.56898e-07, relative limit = 9.76848e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.44541e-12, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.56898e-07, relative limit = 9.76848e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.44541e-12, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02926e-12, relative limit = 9.76848e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.3455e-15, relative limit = 0.000100509, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02926e-12, relative limit = 9.76848e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.3455e-15, relative limit = 0.000100509, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 55
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25244e-05, relative limit = 9.64342e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74932e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25244e-05, relative limit = 9.64342e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74932e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35683e-07, relative limit = 9.65172e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.29692e-12, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35683e-07, relative limit = 9.65172e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.29692e-12, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.46647e-12, relative limit = 9.65172e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31821e-15, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.46647e-12, relative limit = 9.65172e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31821e-15, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 56
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43233e-05, relative limit = 9.50864e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.69809e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43233e-05, relative limit = 9.50864e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.69809e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.11167e-07, relative limit = 9.5167e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04461e-12, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.11167e-07, relative limit = 9.5167e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04461e-12, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10175e-12, relative limit = 9.5167e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.20174e-13, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10175e-12, relative limit = 9.5167e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.20174e-13, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 57
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.60662e-05, relative limit = 9.35618e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64015e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.60662e-05, relative limit = 9.35618e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64015e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.83448e-07, relative limit = 9.36396e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.09895e-12, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.83448e-07, relative limit = 9.36396e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.09895e-12, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.83321e-12, relative limit = 9.36396e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.75228e-15, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.83321e-12, relative limit = 9.36396e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.75228e-15, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 58
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.77462e-05, relative limit = 9.18662e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57576e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.77462e-05, relative limit = 9.18662e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57576e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.52641e-07, relative limit = 9.1941e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.92182e-12, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.52641e-07, relative limit = 9.1941e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.92182e-12, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.2854e-12, relative limit = 9.1941e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37129e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.2854e-12, relative limit = 9.1941e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37129e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 59
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.93565e-05, relative limit = 9.00065e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50514e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.93565e-05, relative limit = 9.00065e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50514e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.18867e-07, relative limit = 9.00778e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.02227e-12, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.18867e-07, relative limit = 9.00778e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.02227e-12, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24528e-12, relative limit = 9.00778e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70888e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24528e-12, relative limit = 9.00778e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70888e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 60
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08907e-05, relative limit = 8.79899e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42859e-06, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08907e-05, relative limit = 8.79899e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42859e-06, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.82252e-07, relative limit = 8.80576e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11123e-11, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.82252e-07, relative limit = 8.80576e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11123e-11, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.70815e-12, relative limit = 8.80576e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43847e-14, relative limit = 0.000100508, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.70815e-12, relative limit = 8.80576e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.43847e-14, relative limit = 0.000100508, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 61
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.23426e-05, relative limit = 8.58243e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3464e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.23426e-05, relative limit = 8.58243e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3464e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4295e-07, relative limit = 8.58881e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.80485e-14, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4295e-07, relative limit = 8.58881e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.80485e-14, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.52399e-14, relative limit = 8.58881e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21619e-15, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.52399e-14, relative limit = 8.58881e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21619e-15, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 62
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.37065e-05, relative limit = 8.35184e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25889e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.37065e-05, relative limit = 8.35184e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25889e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.01096e-07, relative limit = 8.35781e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.74533e-11, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.01096e-07, relative limit = 8.35781e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.74533e-11, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.82653e-12, relative limit = 8.35781e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.0442e-12, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.82653e-12, relative limit = 8.35781e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.0442e-12, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 63
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.4977e-05, relative limit = 8.10812e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.16642e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.4977e-05, relative limit = 8.10812e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.16642e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56879e-07, relative limit = 8.11365e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.21967e-11, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56879e-07, relative limit = 8.11365e-09, conv = false
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.21967e-11, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.22593e-12, relative limit = 8.11365e-09, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08279e-14, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.22593e-12, relative limit = 8.11365e-09, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08279e-14, relative limit = 0.000100507, conv = true
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:19 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 64
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61491e-05, relative limit = 7.85224e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06935e-06, relative limit = 0.000100507, conv = true
-(0) 18:26:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61491e-05, relative limit = 7.85224e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06935e-06, relative limit = 0.000100507, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.10475e-07, relative limit = 7.85731e-09, conv = false
-(0) 18:26:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.6883e-13, relative limit = 0.000100507, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.10475e-07, relative limit = 7.85731e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.6883e-13, relative limit = 0.000100507, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23466e-13, relative limit = 7.85731e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1528e-15, relative limit = 0.000100507, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.23466e-13, relative limit = 7.85731e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1528e-15, relative limit = 0.000100507, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 65
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7218e-05, relative limit = 7.58521e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.68072e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7218e-05, relative limit = 7.58521e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.68072e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.62026e-07, relative limit = 7.58979e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.87296e-11, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.62026e-07, relative limit = 7.58979e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.87296e-11, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02797e-11, relative limit = 7.58979e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.20835e-12, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02797e-11, relative limit = 7.58979e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.20835e-12, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 66
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.81796e-05, relative limit = 7.30807e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.62975e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.81796e-05, relative limit = 7.30807e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.62975e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.11772e-07, relative limit = 7.31216e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.41986e-11, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.11772e-07, relative limit = 7.31216e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.41986e-11, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.30682e-11, relative limit = 7.31216e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44806e-14, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.30682e-11, relative limit = 7.31216e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44806e-14, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 67
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90301e-05, relative limit = 7.02193e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54484e-07, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.90301e-05, relative limit = 7.02193e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54484e-07, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.5992e-07, relative limit = 7.0255e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.2382e-13, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.5992e-07, relative limit = 7.0255e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.2382e-13, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.99437e-13, relative limit = 7.0255e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.11817e-15, relative limit = 0.000100506, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.99437e-13, relative limit = 7.0255e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.11817e-15, relative limit = 0.000100506, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 68
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.97661e-05, relative limit = 6.72791e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4303e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.97661e-05, relative limit = 6.72791e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4303e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.0663e-07, relative limit = 6.73095e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1378e-11, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.0663e-07, relative limit = 6.73095e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1378e-11, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.31606e-12, relative limit = 6.73095e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.19e-12, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.31606e-12, relative limit = 6.73095e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.19e-12, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 69
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03848e-05, relative limit = 6.42717e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.29063e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03848e-05, relative limit = 6.42717e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.29063e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.52131e-07, relative limit = 6.42967e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89476e-11, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.52131e-07, relative limit = 6.42967e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89476e-11, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.03765e-12, relative limit = 6.42967e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.8041e-14, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.03765e-12, relative limit = 6.42967e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.8041e-14, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 70
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.08835e-05, relative limit = 6.1209e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.13042e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.08835e-05, relative limit = 6.1209e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.13042e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.96622e-07, relative limit = 6.12285e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.2883e-13, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.96622e-07, relative limit = 6.12285e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.2883e-13, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.45597e-13, relative limit = 6.12285e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33227e-15, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.45597e-13, relative limit = 6.12285e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.33227e-15, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 71
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12604e-05, relative limit = 5.81031e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.95476e-07, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12604e-05, relative limit = 5.81031e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.95476e-07, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40349e-07, relative limit = 5.8117e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41073e-11, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40349e-07, relative limit = 5.8117e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41073e-11, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94192e-12, relative limit = 5.8117e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.86284e-12, relative limit = 0.000100505, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94192e-12, relative limit = 5.8117e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.86284e-12, relative limit = 0.000100505, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 72
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15141e-05, relative limit = 5.49662e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76995e-07, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15141e-05, relative limit = 5.49662e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76995e-07, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35231e-08, relative limit = 5.49745e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.24476e-11, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35231e-08, relative limit = 5.49745e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.24476e-11, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08186e-12, relative limit = 5.49745e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.70372e-14, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08186e-12, relative limit = 5.49745e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.70372e-14, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 73
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16434e-05, relative limit = 5.18108e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.95656e-08, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16434e-05, relative limit = 5.18108e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.95656e-08, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.63794e-08, relative limit = 5.18134e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.96913e-13, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.63794e-08, relative limit = 5.18134e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.96913e-13, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.77856e-13, relative limit = 5.18134e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31821e-15, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.77856e-13, relative limit = 5.18134e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31821e-15, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 74
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16479e-05, relative limit = 4.86492e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.63607e-08, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.16479e-05, relative limit = 4.86492e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.63607e-08, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09188e-08, relative limit = 4.86461e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.12414e-13, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09188e-08, relative limit = 4.86461e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.12414e-13, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.87427e-13, relative limit = 4.86461e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70556e-15, relative limit = 0.000100504, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.87427e-13, relative limit = 4.86461e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70556e-15, relative limit = 0.000100504, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 75
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15275e-05, relative limit = 4.5494e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.84064e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15275e-05, relative limit = 4.5494e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.84064e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.80443e-08, relative limit = 4.54853e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.27314e-13, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.80443e-08, relative limit = 4.54853e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.27314e-13, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.91649e-13, relative limit = 4.54853e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.88658e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.91649e-13, relative limit = 4.54853e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.88658e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 76
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12828e-05, relative limit = 4.23575e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.02506e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12828e-05, relative limit = 4.23575e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.02506e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44831e-07, relative limit = 4.23432e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.01563e-13, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44831e-07, relative limit = 4.23432e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.01563e-13, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.77519e-13, relative limit = 4.23432e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.98445e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.77519e-13, relative limit = 4.23432e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.98445e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 77
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09147e-05, relative limit = 3.92523e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.19981e-07, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09147e-05, relative limit = 3.92523e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.19981e-07, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01047e-07, relative limit = 3.92324e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.99272e-13, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01047e-07, relative limit = 3.92324e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.99272e-13, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.78025e-13, relative limit = 3.92324e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.00297e-15, relative limit = 0.000100503, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.78025e-13, relative limit = 3.92324e-09, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.00297e-15, relative limit = 0.000100503, conv = true
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 78
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04247e-05, relative limit = 3.61905e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.35876e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04247e-05, relative limit = 3.61905e-09, conv = false
+(0) 16:22:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.35876e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.5645e-07, relative limit = 3.61651e-09, conv = false
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.54053e-11, relative limit = 0.000100502, conv = true
-(0) 18:26:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.5645e-07, relative limit = 3.61651e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.54053e-11, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67342e-11, relative limit = 3.61651e-09, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.27719e-12, relative limit = 0.000100502, conv = true
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:39 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67342e-11, relative limit = 3.61651e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.27719e-12, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 79
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98146e-05, relative limit = 3.31843e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.49682e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.98146e-05, relative limit = 3.31843e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.49682e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.10859e-07, relative limit = 3.31535e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.7342e-11, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.10859e-07, relative limit = 3.31535e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.7342e-11, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64125e-11, relative limit = 3.31535e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.34348e-13, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64125e-11, relative limit = 3.31535e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.34348e-13, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 80
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9087e-05, relative limit = 3.02454e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.60955e-07, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9087e-05, relative limit = 3.02454e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.60955e-07, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6406e-07, relative limit = 3.02094e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.39663e-13, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.6406e-07, relative limit = 3.02094e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.39663e-13, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.00291e-13, relative limit = 3.02094e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46321e-14, relative limit = 0.000100502, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.00291e-13, relative limit = 3.02094e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46321e-14, relative limit = 0.000100502, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 81
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82446e-05, relative limit = 2.73855e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.69237e-07, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.82446e-05, relative limit = 2.73855e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.69237e-07, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15807e-07, relative limit = 2.73444e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.53338e-13, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.15807e-07, relative limit = 2.73444e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.53338e-13, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51682e-13, relative limit = 2.73444e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.43624e-15, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51682e-13, relative limit = 2.73444e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.43624e-15, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 82
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72908e-05, relative limit = 2.46159e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.74092e-07, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72908e-05, relative limit = 2.46159e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.74092e-07, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65897e-07, relative limit = 2.45698e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41709e-11, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65897e-07, relative limit = 2.45698e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41709e-11, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.55981e-11, relative limit = 2.45698e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.16654e-13, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.55981e-11, relative limit = 2.45698e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.16654e-13, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 83
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.62295e-05, relative limit = 2.19475e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0751e-06, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.62295e-05, relative limit = 2.19475e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0751e-06, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.14158e-07, relative limit = 2.18967e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81357e-11, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.14158e-07, relative limit = 2.18967e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.81357e-11, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76857e-11, relative limit = 2.18967e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43072e-13, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76857e-11, relative limit = 2.18967e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43072e-13, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 84
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.50647e-05, relative limit = 1.93909e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17188e-06, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.50647e-05, relative limit = 1.93909e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17188e-06, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.6041e-07, relative limit = 1.93355e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.30739e-13, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.6041e-07, relative limit = 1.93355e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.30739e-13, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5094e-13, relative limit = 1.93355e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61787e-15, relative limit = 0.000100501, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5094e-13, relative limit = 1.93355e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61787e-15, relative limit = 0.000100501, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 85
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38011e-05, relative limit = 1.69561e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26403e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38011e-05, relative limit = 1.69561e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26403e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.04423e-07, relative limit = 1.68964e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.6576e-11, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.04423e-07, relative limit = 1.68964e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.6576e-11, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.64806e-12, relative limit = 1.68964e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56612e-13, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.64806e-12, relative limit = 1.68964e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56612e-13, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 86
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24437e-05, relative limit = 1.46528e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3512e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.24437e-05, relative limit = 1.46528e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3512e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46057e-07, relative limit = 1.4589e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15791e-11, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46057e-07, relative limit = 1.4589e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15791e-11, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47809e-11, relative limit = 1.4589e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65968e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47809e-11, relative limit = 1.4589e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65968e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 87
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09979e-05, relative limit = 1.249e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43303e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09979e-05, relative limit = 1.249e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.43303e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85149e-07, relative limit = 1.24224e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.80135e-11, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85149e-07, relative limit = 1.24224e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.80135e-11, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22932e-11, relative limit = 1.24224e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.55516e-13, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22932e-11, relative limit = 1.24224e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.55516e-13, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 88
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94694e-05, relative limit = 1.04763e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50922e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94694e-05, relative limit = 1.04763e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50922e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21545e-07, relative limit = 1.04053e-09, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.52567e-13, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21545e-07, relative limit = 1.04053e-09, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.52567e-13, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.38252e-14, relative limit = 1.04053e-09, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47288e-15, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.38252e-14, relative limit = 1.04053e-09, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47288e-15, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 89
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.78643e-05, relative limit = 8.61973e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57944e-06, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.78643e-05, relative limit = 8.61973e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57944e-06, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55055e-07, relative limit = 8.54547e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.75769e-11, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55055e-07, relative limit = 8.54547e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.75769e-11, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.535e-11, relative limit = 8.54547e-10, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.49667e-12, relative limit = 0.0001005, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.535e-11, relative limit = 8.54547e-10, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.49667e-12, relative limit = 0.0001005, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 90
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61891e-05, relative limit = 6.92757e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64344e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61891e-05, relative limit = 6.92757e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64344e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.85613e-07, relative limit = 6.85043e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.4027e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.85613e-07, relative limit = 6.85043e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.4027e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.40956e-11, relative limit = 6.85043e-10, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.01168e-13, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.40956e-11, relative limit = 6.85043e-10, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.01168e-13, relative limit = 0.000100499, conv = true
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 91
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44504e-05, relative limit = 5.40655e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70095e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44504e-05, relative limit = 5.40655e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70095e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.13068e-07, relative limit = 5.3269e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.88067e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.13068e-07, relative limit = 5.3269e-10, conv = false
+(0) 16:22:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.88067e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66339e-11, relative limit = 5.3269e-10, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56705e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66339e-11, relative limit = 5.3269e-10, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56705e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 92
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26553e-05, relative limit = 4.06274e-10, conv = false
-(0) 18:26:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75176e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26553e-05, relative limit = 4.06274e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75176e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37326e-07, relative limit = 3.98101e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.1016e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37326e-07, relative limit = 3.98101e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.1016e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83149e-11, relative limit = 3.98101e-10, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.51429e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83149e-11, relative limit = 3.98101e-10, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.51429e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 93
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08111e-05, relative limit = 2.9016e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79565e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08111e-05, relative limit = 2.9016e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.79565e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.58302e-07, relative limit = 2.81827e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93059e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.58302e-07, relative limit = 2.81827e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93059e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24223e-11, relative limit = 2.81827e-10, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.99193e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24223e-11, relative limit = 2.81827e-10, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.99193e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 94
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.92577e-06, relative limit = 1.92796e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83246e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.92577e-06, relative limit = 1.92796e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.83246e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.7586e-07, relative limit = 1.84376e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.89097e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.7586e-07, relative limit = 1.84376e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.89097e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3029e-11, relative limit = 1.84376e-10, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9379e-15, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3029e-11, relative limit = 1.84376e-10, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9379e-15, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 95
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.00791e-06, relative limit = 1.14633e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86203e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.00791e-06, relative limit = 1.14633e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86203e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.89971e-07, relative limit = 1.06259e-10, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.43622e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.89971e-07, relative limit = 1.06259e-10, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.43622e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31739e-11, relative limit = 1.06259e-10, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26489e-13, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.31739e-11, relative limit = 1.06259e-10, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26489e-13, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 96
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.06815e-06, relative limit = 5.61984e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88426e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.06815e-06, relative limit = 5.61984e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88426e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00559e-07, relative limit = 4.82997e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.94732e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00559e-07, relative limit = 4.82997e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.94732e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06027e-11, relative limit = 4.82999e-11, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.77867e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06027e-11, relative limit = 4.82999e-11, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.77867e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 97
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12488e-06, relative limit = 1.89533e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89906e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12488e-06, relative limit = 1.89533e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89906e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07564e-07, relative limit = 1.50898e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.55509e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07564e-07, relative limit = 1.50898e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.55509e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17954e-11, relative limit = 1.50898e-11, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.19972e-13, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17954e-11, relative limit = 1.50898e-11, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.19972e-13, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 98
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26414e-06, relative limit = 9.92428e-12, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90637e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.26414e-06, relative limit = 9.92428e-12, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90637e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11027e-07, relative limit = 1.76381e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17297e-11, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.11027e-07, relative limit = 1.76381e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17297e-11, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76207e-12, relative limit = 1.76382e-11, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.76847e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76207e-12, relative limit = 1.76382e-11, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.76847e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
 Advancing in time, finished timestep: 99
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.1464e-06, relative limit = 6.41399e-12, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90615e-06, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.1464e-06, relative limit = 6.41399e-12, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90615e-06, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.10896e-07, relative limit = 1.54491e-11, conv = false
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.13034e-12, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.10896e-07, relative limit = 1.54491e-11, conv = false
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.13034e-12, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 40 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
 Iterate
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9683e-12, relative limit = 1.5449e-11, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9044e-14, relative limit = 0.000100499, conv = true
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 18:26:41 [cplscheme::BaseCouplingScheme]:250 in extrapolateData: [0mPerforming second order extrapolation
-(0) 18:26:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.9683e-12, relative limit = 1.5449e-11, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9044e-14, relative limit = 0.000100499, conv = true
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:277 in extrapolateData: [0mPerforming second order extrapolation
+(0) 16:22:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 40 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
 Exiting StructureSolver

--- a/tests/TestCompose_1dtube_py.Ubuntu1604.home/Dockerfile.tutorial_data
+++ b/tests/TestCompose_1dtube_py.Ubuntu1604.home/Dockerfile.tutorial_data
@@ -6,5 +6,5 @@ ARG branch=develop
 WORKDIR /
 # adjust configuration and paths
 RUN mkdir /Output
-RUN addgroup -g 1000 precice && adduser -u 1000 -G precice -D precice /Output
+RUN addgroup -g 1000 precice && adduser -u 1000 -G precice -D precice && chown -R precice:precice /Output
 USER precice

--- a/tests/TestCompose_1dtube_py.Ubuntu1604.home/docker-compose.yml
+++ b/tests/TestCompose_1dtube_py.Ubuntu1604.home/docker-compose.yml
@@ -12,9 +12,6 @@ services:
       - output:/home/precice/Data/Output/
     command: >
       /bin/bash -c "./Allrun &&
-        ls -la &&
-        echo "yee" &&
-        ls -la /home/precice/Data &&
         cp -r *.log VTK /home/precice/Data/Output/ &&
         rm /home/precice/Data/Output/*summary.log"
     container_name: 1dtube-py

--- a/tests/TestCompose_1dtube_py.Ubuntu1604.home/docker-compose.yml
+++ b/tests/TestCompose_1dtube_py.Ubuntu1604.home/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - output:/home/precice/Data/Output/
     command: >
       /bin/bash -c "./Allrun &&
+        ls -la &&
+        echo "yee" &&
+        ls -la /home/precice/Data &&
         cp -r *.log VTK /home/precice/Data/Output/ &&
         rm /home/precice/Data/Output/*summary.log"
     container_name: 1dtube-py

--- a/tests/TestCompose_1dtube_py.Ubuntu1604.home/referenceOutput/Fluid.log
+++ b/tests/TestCompose_1dtube_py.Ubuntu1604.home/referenceOutput/Fluid.log
@@ -1,953 +1,953 @@
-Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/HQL7GMSCAWESPOG3RKZBLIXNXR:/var/lib/docker/overlay2/l/EM4H4HRUFQQR3H5WQFNDJDRCVH:/var/lib/docker/overlay2/l/GOCJCNVCLXMQFVT6HJT3H4SQDX:/var/lib/docker/overlay2/l/52H4FUQNS6EJC22FRVTISKNRGL:/var/lib/docker/overlay2/l/C2E4CV7O2CSOP5KW4IUIMCRBFJ:/var/lib/docker/overlay2/l/WUGWJQO22XD45O4REP24E7AYK6:/var/lib/docker/overlay2/l/HSBP5PW67OLKEIEQBOBNZDCEZJ:/var/lib/docker/overlay2/l/7HSMLK6ACQU4BMEF75APA2DOEP:/var/lib/docker/overlay2/l/XX4VVBJDLTLWV'
-Unexpected end of /proc/mounts line `EAWOVLCMH36B6:/var/lib/docker/overlay2/l/FM7QIXMVW6YQH6WRWUBL5SFHWA:/var/lib/docker/overlay2/l/ZGKPJEZUPHKA5HKCPWZGC6OGI5:/var/lib/docker/overlay2/l/INZLXHJH6KEVH2KQ7CSKGFVNK3:/var/lib/docker/overlay2/l/FTCZXRTKTPFDO2TD4SXMJPKMUQ:/var/lib/docker/overlay2/l/JNFKDKBTR5QI6RR557TT6L2E7X:/var/lib/docker/overlay2/l/Z34HHFDCRJ2L4RTCPTK7ZKEDLP:/var/lib/docker/overlay2/l/5MK3D7H32R4PPNJKAODZLVPIU4:/var/lib/docker/overlay2/l/4XBMHAPZAMKOHTDUMGVXU465W6:/var/lib/docker/overlay2/l/SPGZGV3RK4LAKTRFW4I7UR6ISZ:/var/lib/do'
-(0) 16:21:38 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
-(0) 16:21:38 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-67-ga8e5025
-(0) 16:21:38 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
-(0) 16:21:38 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "FLUID"
-(0) 16:21:38 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
-(0) 16:21:38 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
-(0) 16:21:38 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
-(0) 16:21:38 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Fluid_Nodes
-(0) 16:21:38 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Structure_Nodes
-(0) 16:21:38 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
-(0) 16:21:38 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
-(0) 16:21:38 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:1255 in mapWrittenData: [0mCompute write mapping from mesh "Fluid_Nodes" to mesh "Structure_Nodes".
-(0) 16:21:38 [mapping::NearestProjectionMapping]:78 in computeMapping: [36mWARNING: [0m2D Mesh "Fluid_Nodes" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.
-(0) 16:21:38 [mapping::NearestProjectionMapping]:129 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
-(0) 16:21:38 [impl::SolverInterfaceImpl]:1305 in mapReadData: [0mCompute read mapping from mesh "Structure_Nodes" to mesh "Fluid_Nodes".
-(0) 16:21:38 [mapping::NearestProjectionMapping]:78 in computeMapping: [36mWARNING: [0m2D Mesh "Structure_Nodes" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.
-(0) 16:21:38 [mapping::NearestProjectionMapping]:129 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 11 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 12 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 13 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 14 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 15 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 16 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 17 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 18 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 19 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 20 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
+Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/EEEQSQRXSJ7J3DPGNYG4PV2WGQ:/var/lib/docker/overlay2/l/K7M3MWVCA4P4KKYKW7MGVCY3N5:/var/lib/docker/overlay2/l/JOUPYORPWF4TJQC5NK7Y3DUUPO:/var/lib/docker/overlay2/l/WJOR2Q2I7OSBQ3KGKCEWDDLVCD:/var/lib/docker/overlay2/l/PKRYWMTEUHURBUMXUKZZZMUNP2:/var/lib/docker/overlay2/l/BBQG4M7QFFJEYRNSG42NCXGMVY:/var/lib/docker/overlay2/l/KTJAP5NDGS23HT6HPSRUEPS4KD:/var/lib/docker/overlay2/l/DX6BE3UFBR4OBR6CZ4G3CXWCMR:/var/lib/docker/overlay2/l/SP5WTFZRYUKER'
+Unexpected end of /proc/mounts line `WSEQZA5Z467SV:/var/lib/docker/overlay2/l/AGV3IYG5SLJ7IYUVH7OGWIQJTL:/var/lib/docker/overlay2/l/G35TYUGGVV5WFCIKELRGVBLIOA:/var/lib/docker/overlay2/l/4PFCH2B2FRXOOWB7HWRLAYXFIE:/var/lib/docker/overlay2/l/CO7L75I2WTWXRCZDEZGJAAJBXF:/var/lib/docker/overlay2/l/5NMGGQ4OZJUV6OQIK2JMH42LQA:/var/lib/docker/overlay2/l/ZVYOZXGEG6DF4I4A7SO2DIOT5Z:/var/lib/docker/overlay2/l/CAXPKD6OZP3VUJ5NZ4CFWIHSIT:/var/lib/docker/overlay2/l/QXWGBUR4EMFAZK3NZGWEEKHHFS:/var/lib/docker/overlay2/l/4D4UPT5SC6CCA5E4MPJYYJUUPD:/var/lib/do'
+(0) 16:23:38 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
+(0) 16:23:38 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-72-g657f759
+(0) 16:23:38 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
+(0) 16:23:38 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "FLUID"
+(0) 16:23:38 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
+(0) 16:23:38 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
+(0) 16:23:38 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
+(0) 16:23:38 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Fluid_Nodes
+(0) 16:23:38 [partition::ReceivedPartition]:60 in communicate: [0mReceive global mesh Structure_Nodes
+(0) 16:23:38 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
+(0) 16:23:38 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
+(0) 16:23:38 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:1259 in mapWrittenData: [0mCompute write mapping from mesh "Fluid_Nodes" to mesh "Structure_Nodes".
+(0) 16:23:38 [mapping::NearestProjectionMapping]:78 in computeMapping: [36mWARNING: [0m2D Mesh "Fluid_Nodes" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.
+(0) 16:23:38 [mapping::NearestProjectionMapping]:129 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
+(0) 16:23:38 [impl::SolverInterfaceImpl]:1309 in mapReadData: [0mCompute read mapping from mesh "Structure_Nodes" to mesh "Fluid_Nodes".
+(0) 16:23:38 [mapping::NearestProjectionMapping]:78 in computeMapping: [36mWARNING: [0m2D Mesh "Structure_Nodes" does not contain edges. Nearest projection mapping falls back to nearest neighbor mapping.
+(0) 16:23:38 [mapping::NearestProjectionMapping]:129 in computeMapping: [0mMapping distance min:0 max:0 avg: 0 var: 0 cnt: 101
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 11 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 12 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 13 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 14 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 15 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 16 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 17 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 18 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 19 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 20 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
 Starting Fluid Solver...
 N: 100
 Configure preCICE...

--- a/tests/TestCompose_1dtube_py.Ubuntu1604.home/referenceOutput/Structure.log
+++ b/tests/TestCompose_1dtube_py.Ubuntu1604.home/referenceOutput/Structure.log
@@ -1,2708 +1,2708 @@
-Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/HQL7GMSCAWESPOG3RKZBLIXNXR:/var/lib/docker/overlay2/l/EM4H4HRUFQQR3H5WQFNDJDRCVH:/var/lib/docker/overlay2/l/GOCJCNVCLXMQFVT6HJT3H4SQDX:/var/lib/docker/overlay2/l/52H4FUQNS6EJC22FRVTISKNRGL:/var/lib/docker/overlay2/l/C2E4CV7O2CSOP5KW4IUIMCRBFJ:/var/lib/docker/overlay2/l/WUGWJQO22XD45O4REP24E7AYK6:/var/lib/docker/overlay2/l/HSBP5PW67OLKEIEQBOBNZDCEZJ:/var/lib/docker/overlay2/l/7HSMLK6ACQU4BMEF75APA2DOEP:/var/lib/docker/overlay2/l/XX4VVBJDLTLWV'
-Unexpected end of /proc/mounts line `EAWOVLCMH36B6:/var/lib/docker/overlay2/l/FM7QIXMVW6YQH6WRWUBL5SFHWA:/var/lib/docker/overlay2/l/ZGKPJEZUPHKA5HKCPWZGC6OGI5:/var/lib/docker/overlay2/l/INZLXHJH6KEVH2KQ7CSKGFVNK3:/var/lib/docker/overlay2/l/FTCZXRTKTPFDO2TD4SXMJPKMUQ:/var/lib/docker/overlay2/l/JNFKDKBTR5QI6RR557TT6L2E7X:/var/lib/docker/overlay2/l/Z34HHFDCRJ2L4RTCPTK7ZKEDLP:/var/lib/docker/overlay2/l/5MK3D7H32R4PPNJKAODZLVPIU4:/var/lib/docker/overlay2/l/4XBMHAPZAMKOHTDUMGVXU465W6:/var/lib/docker/overlay2/l/SPGZGV3RK4LAKTRFW4I7UR6ISZ:/var/lib/do'
-(0) 16:21:37 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
-(0) 16:21:37 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-67-ga8e5025
-(0) 16:21:37 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
-(0) 16:21:37 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "STRUCTURE"
-(0) 16:21:37 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
-(0) 16:21:38 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
-(0) 16:21:38 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
-(0) 16:21:38 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Structure_Nodes
-(0) 16:21:38 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Structure_Nodes
-(0) 16:21:38 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Structure_Nodes
-(0) 16:21:38 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
-(0) 16:21:38 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
-(0) 16:21:38 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-initial-data | write-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6165.01, relative limit = 0.0616501, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.743701, relative limit = 0.00010718, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3533.04, relative limit = 0.0267591, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.304414, relative limit = 0.000103132, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3314.03, relative limit = 0.0457024, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.569663, relative limit = 0.000105534, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5215.97, relative limit = 0.079823, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.968817, relative limit = 0.000109217, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4011.76, relative limit = 0.0400411, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.458885, relative limit = 0.000104684, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4662.18, relative limit = 0.00803247, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.093555, relative limit = 9.98625e-05, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 419.679, relative limit = 0.0101152, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.121046, relative limit = 9.96263e-05, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1307.95, relative limit = 0.00401018, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0274171, relative limit = 0.000100854, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 200.627, relative limit = 0.00238801, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00467666, relative limit = 0.000100645, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.4962, relative limit = 0.00222247, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00216145, relative limit = 0.000100617, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 11 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.1818, relative limit = 0.00212782, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000799294, relative limit = 0.000100608, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 12 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.67166, relative limit = 0.00212736, conv = false
-(0) 16:21:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000649543, relative limit = 0.000100611, conv = false
-(0) 16:21:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 13 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.78319, relative limit = 0.00208865, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106639, relative limit = 0.000100608, conv = false
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 14 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.674052, relative limit = 0.00208548, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.10333e-05, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 15 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122316, relative limit = 0.00208472, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.72578e-05, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 16 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0780042, relative limit = 0.00208433, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.43453e-06, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 17 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0561891, relative limit = 0.00208405, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08659e-06, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 18 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149142, relative limit = 0.00208398, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03769e-07, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 19 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00380535, relative limit = 0.00208396, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.52936e-08, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 20 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000281898, relative limit = 0.00208396, conv = true
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.51638e-09, relative limit = 0.000100607, conv = true
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12146.8, relative limit = 0.122861, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57201, relative limit = 0.000114844, conv = false
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12108.6, relative limit = 0.0128916, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.166286, relative limit = 0.000101103, conv = false
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1409.58, relative limit = 0.00263847, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0519035, relative limit = 0.000100403, conv = false
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 271.453, relative limit = 0.00369663, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0200367, relative limit = 0.000100652, conv = false
-(0) 16:21:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 172.855, relative limit = 0.00505874, conv = false
-(0) 16:21:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000477047, relative limit = 0.000100811, conv = false
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.53876, relative limit = 0.00502772, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.26161e-05, relative limit = 0.000100809, conv = true
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.494316, relative limit = 0.00502542, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17997e-05, relative limit = 0.00010081, conv = true
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0815479, relative limit = 0.00502599, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43735e-06, relative limit = 0.00010081, conv = true
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177596, relative limit = 0.00502608, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.38037e-07, relative limit = 0.00010081, conv = true
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00394795, relative limit = 0.00502612, conv = true
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41649e-08, relative limit = 0.00010081, conv = true
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16550.5, relative limit = 0.169287, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26335, relative limit = 0.000121494, conv = false
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17272.7, relative limit = 0.00484477, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.124546, relative limit = 0.000100117, conv = false
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 752.682, relative limit = 0.00573348, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0365783, relative limit = 0.0001008, conv = false
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 265.181, relative limit = 0.00792483, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00528231, relative limit = 0.000101045, conv = false
-(0) 16:21:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.6007, relative limit = 0.00833741, conv = false
-(0) 16:21:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000343969, relative limit = 0.00010109, conv = false
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49309, relative limit = 0.0083144, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.33775e-05, relative limit = 0.000101088, conv = true
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.34328, relative limit = 0.00831125, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66769e-06, relative limit = 0.000101088, conv = true
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0160645, relative limit = 0.00831112, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37897e-07, relative limit = 0.000101088, conv = true
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00640699, relative limit = 0.00831106, conv = true
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.05922e-08, relative limit = 0.000101088, conv = true
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18774.1, relative limit = 0.194531, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.64444, relative limit = 0.000125488, conv = false
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18379.3, relative limit = 0.0130607, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0311455, relative limit = 0.000101426, conv = false
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 250.096, relative limit = 0.0106402, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0146111, relative limit = 0.000101291, conv = false
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 104.613, relative limit = 0.0113552, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00210778, relative limit = 0.000101396, conv = false
-(0) 16:21:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.5665, relative limit = 0.0115202, conv = false
-(0) 16:21:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32346e-05, relative limit = 0.000101413, conv = true
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180996, relative limit = 0.0115198, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.85222e-05, relative limit = 0.000101413, conv = true
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126225, relative limit = 0.0115209, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63625e-06, relative limit = 0.000101413, conv = true
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.029986, relative limit = 0.0115212, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14348e-08, relative limit = 0.000101413, conv = true
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000309636, relative limit = 0.0115212, conv = true
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.07888e-09, relative limit = 0.000101413, conv = true
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18488.6, relative limit = 0.194886, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.59978, relative limit = 0.000125652, conv = false
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17729.1, relative limit = 0.019528, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.068649, relative limit = 0.00010216, conv = false
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 598.762, relative limit = 0.0135888, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00893535, relative limit = 0.000101673, conv = false
-(0) 16:21:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 75.9334, relative limit = 0.0143151, conv = false
-(0) 16:21:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0001122, relative limit = 0.00010175, conv = false
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.899986, relative limit = 0.0143107, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.18755e-06, relative limit = 0.00010175, conv = true
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0587134, relative limit = 0.0143106, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07823e-06, relative limit = 0.00010175, conv = true
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0222289, relative limit = 0.0143104, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.27414e-07, relative limit = 0.00010175, conv = true
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00330534, relative limit = 0.0143104, conv = true
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.30564e-08, relative limit = 0.00010175, conv = true
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15669.5, relative limit = 0.169663, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.13334, relative limit = 0.000121889, conv = false
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 14423.8, relative limit = 0.0271723, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.134743, relative limit = 0.000103043, conv = false
-(0) 16:21:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 939.669, relative limit = 0.0178336, conv = false
-(0) 16:21:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0172954, relative limit = 0.000102191, conv = false
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 138.785, relative limit = 0.0164501, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00041797, relative limit = 0.000102062, conv = false
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11993, relative limit = 0.016423, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68655e-05, relative limit = 0.000102059, conv = true
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.532023, relative limit = 0.016419, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.54402e-05, relative limit = 0.000102058, conv = true
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110826, relative limit = 0.0164201, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87027e-06, relative limit = 0.000102058, conv = true
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0154785, relative limit = 0.0164202, conv = true
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.95439e-08, relative limit = 0.000102058, conv = true
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10628.8, relative limit = 0.121495, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.36818, relative limit = 0.000115201, conv = false
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9308.46, relative limit = 0.0299392, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.151981, relative limit = 0.000103501, conv = false
-(0) 16:21:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 911.606, relative limit = 0.020904, conv = false
-(0) 16:21:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0394008, relative limit = 0.000102613, conv = false
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 319.679, relative limit = 0.0177452, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000551635, relative limit = 0.000102305, conv = false
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46456, relative limit = 0.017702, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74288e-05, relative limit = 0.0001023, conv = true
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.115237, relative limit = 0.0177014, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12381e-06, relative limit = 0.0001023, conv = true
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00563551, relative limit = 0.0177014, conv = true
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.72169e-07, relative limit = 0.0001023, conv = true
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4228.95, relative limit = 0.0573698, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.510009, relative limit = 0.000107099, conv = false
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3483.29, relative limit = 0.0252518, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0878921, relative limit = 0.000103179, conv = false
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 671.92, relative limit = 0.0186843, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0067114, relative limit = 0.0001025, conv = false
-(0) 16:21:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 49.6178, relative limit = 0.0181919, conv = false
-(0) 16:21:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000756023, relative limit = 0.000102448, conv = false
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.2874, relative limit = 0.0181301, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56893e-06, relative limit = 0.000102442, conv = true
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0715704, relative limit = 0.0181295, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.12984e-06, relative limit = 0.000102442, conv = true
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0341514, relative limit = 0.0181299, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.75484e-08, relative limit = 0.000102442, conv = true
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00026569, relative limit = 0.0181299, conv = true
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.76946e-09, relative limit = 0.000102442, conv = true
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4919.86, relative limit = 0.0358635, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.539987, relative limit = 9.89571e-05, conv = false
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4393.14, relative limit = 0.016888, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0391464, relative limit = 0.000102316, conv = false
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 273.556, relative limit = 0.0178207, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00378493, relative limit = 0.000102456, conv = false
-(0) 16:21:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.7737, relative limit = 0.0178254, conv = false
-(0) 16:21:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000397235, relative limit = 0.000102459, conv = false
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.37756, relative limit = 0.0178173, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.97154e-05, relative limit = 0.000102458, conv = true
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.557688, relative limit = 0.0178147, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21908e-06, relative limit = 0.000102457, conv = true
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0436967, relative limit = 0.0178145, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.63905e-06, relative limit = 0.000102457, conv = true
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0122344, relative limit = 0.0178144, conv = true
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12355e-08, relative limit = 0.000102457, conv = true
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12461.7, relative limit = 0.109261, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2711, relative limit = 9.16979e-05, conv = false
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11052.9, relative limit = 0.0112798, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.129551, relative limit = 0.000101258, conv = false
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1187.82, relative limit = 0.0174964, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0099633, relative limit = 0.000102405, conv = false
-(0) 16:21:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 68.0961, relative limit = 0.0170793, conv = false
-(0) 16:21:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00174317, relative limit = 0.000102346, conv = false
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13.0016, relative limit = 0.0170016, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000177191, relative limit = 0.000102335, conv = false
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.46767, relative limit = 0.016994, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03011e-06, relative limit = 0.000102334, conv = true
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0366602, relative limit = 0.0169943, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56535e-06, relative limit = 0.000102334, conv = true
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0124476, relative limit = 0.0169943, conv = true
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.66638e-08, relative limit = 0.000102334, conv = true
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19517.8, relative limit = 0.181923, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86823, relative limit = 8.58043e-05, conv = false
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18469, relative limit = 0.0126255, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.076649, relative limit = 0.000101396, conv = false
-(0) 16:21:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 684.014, relative limit = 0.0160539, conv = false
-(0) 16:21:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00426986, relative limit = 0.000102096, conv = false
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 41.7129, relative limit = 0.0159824, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000955157, relative limit = 0.000102066, conv = false
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.71699, relative limit = 0.0160212, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.37506e-05, relative limit = 0.000102074, conv = true
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.476149, relative limit = 0.0160192, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76899e-05, relative limit = 0.000102074, conv = true
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.157122, relative limit = 0.0160184, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47267e-07, relative limit = 0.000102074, conv = true
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00823312, relative limit = 0.0160184, conv = true
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.48761e-07, relative limit = 0.000102074, conv = true
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25058.8, relative limit = 0.240768, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.28381, relative limit = 8.14644e-05, conv = false
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24538.6, relative limit = 0.0128302, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0387785, relative limit = 0.000101551, conv = false
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 223.021, relative limit = 0.0147649, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00793704, relative limit = 0.000101662, conv = false
-(0) 16:21:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 57.1066, relative limit = 0.0152679, conv = false
-(0) 16:21:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000586091, relative limit = 0.000101687, conv = false
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.50616, relative limit = 0.0152826, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.96177e-05, relative limit = 0.000101693, conv = true
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.431794, relative limit = 0.0152821, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.28199e-06, relative limit = 0.000101692, conv = true
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0201834, relative limit = 0.0152822, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18027e-06, relative limit = 0.000101692, conv = true
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00798031, relative limit = 0.0152822, conv = true
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.42578e-07, relative limit = 0.000101692, conv = true
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28444, relative limit = 0.278928, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51294, relative limit = 7.87206e-05, conv = false
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28059.6, relative limit = 0.0124772, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0437367, relative limit = 0.00010125, conv = false
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 271.881, relative limit = 0.0147035, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00847004, relative limit = 0.000101257, conv = false
-(0) 16:21:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 66.1486, relative limit = 0.0150768, conv = false
-(0) 16:21:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000405966, relative limit = 0.000101221, conv = false
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55144, relative limit = 0.015089, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.40797e-05, relative limit = 0.000101218, conv = true
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.247157, relative limit = 0.0150873, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85245e-06, relative limit = 0.000101218, conv = true
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0533453, relative limit = 0.0150875, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.99102e-07, relative limit = 0.000101218, conv = true
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00617198, relative limit = 0.0150875, conv = true
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.04268e-07, relative limit = 0.000101218, conv = true
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29288, relative limit = 0.292121, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.55886, relative limit = 7.75756e-05, conv = false
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29280.5, relative limit = 0.011798, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0736661, relative limit = 0.000101104, conv = false
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 650.031, relative limit = 0.0156987, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00352451, relative limit = 0.000100673, conv = false
-(0) 16:21:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.3141, relative limit = 0.0154824, conv = false
-(0) 16:21:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.25075e-05, relative limit = 0.000100691, conv = true
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.698478, relative limit = 0.0154789, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53411e-05, relative limit = 0.000100692, conv = true
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.228566, relative limit = 0.0154798, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.97292e-07, relative limit = 0.000100692, conv = true
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00426461, relative limit = 0.0154798, conv = true
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63943e-07, relative limit = 0.000100692, conv = true
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27470.3, relative limit = 0.278685, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.4239, relative limit = 7.80568e-05, conv = false
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27893.2, relative limit = 0.0101163, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.114578, relative limit = 0.000100965, conv = false
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 912.418, relative limit = 0.0155535, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00929234, relative limit = 0.000100217, conv = false
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 71.3355, relative limit = 0.0161509, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00106037, relative limit = 0.000100165, conv = false
-(0) 16:21:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00571, relative limit = 0.016225, conv = false
-(0) 16:21:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89612e-05, relative limit = 0.000100158, conv = true
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.283219, relative limit = 0.0162272, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.74146e-06, relative limit = 0.000100158, conv = true
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0277388, relative limit = 0.016227, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.94529e-07, relative limit = 0.000100158, conv = true
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00463592, relative limit = 0.016227, conv = true
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00563e-07, relative limit = 0.000100158, conv = true
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23136.8, relative limit = 0.239609, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10583, relative limit = 8.02491e-05, conv = false
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23769.6, relative limit = 0.00837646, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.128148, relative limit = 0.000100631, conv = false
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1148.87, relative limit = 0.0171982, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00303331, relative limit = 9.96373e-05, conv = false
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28.053, relative limit = 0.0169696, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106124, relative limit = 9.96645e-05, conv = false
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.840465, relative limit = 0.0169752, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10352e-05, relative limit = 9.96637e-05, conv = true
-(0) 16:21:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.106513, relative limit = 0.016976, conv = false
-(0) 16:21:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31913e-06, relative limit = 9.96636e-05, conv = true
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00643433, relative limit = 0.016976, conv = true
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.32484e-07, relative limit = 9.96636e-05, conv = true
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16694.7, relative limit = 0.178483, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5989, relative limit = 8.43003e-05, conv = false
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17768.3, relative limit = 0.00570889, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.16666, relative limit = 0.000100617, conv = false
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1362.82, relative limit = 0.0164068, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0120516, relative limit = 9.93533e-05, conv = false
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 105.045, relative limit = 0.0173957, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000349908, relative limit = 9.92575e-05, conv = false
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76866, relative limit = 0.0174209, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.28626e-05, relative limit = 9.9255e-05, conv = true
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.354395, relative limit = 0.0174242, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.70704e-06, relative limit = 9.92547e-05, conv = true
-(0) 16:21:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0221127, relative limit = 0.0174243, conv = false
-(0) 16:21:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2916e-06, relative limit = 9.92546e-05, conv = true
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00996949, relative limit = 0.0174244, conv = true
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95854e-07, relative limit = 9.92546e-05, conv = true
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8879.38, relative limit = 0.101814, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.908577, relative limit = 9.03896e-05, conv = false
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9651.12, relative limit = 0.00682351, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126501, relative limit = 0.000100038, conv = false
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 955.423, relative limit = 0.0157814, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0186, relative limit = 9.91272e-05, conv = false
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 164.449, relative limit = 0.0173854, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000291064, relative limit = 9.8971e-05, conv = false
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38003, relative limit = 0.0174068, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.5614e-05, relative limit = 9.89691e-05, conv = true
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.234627, relative limit = 0.0174089, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10639e-06, relative limit = 9.89689e-05, conv = true
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0159889, relative limit = 0.0174088, conv = true
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41775e-07, relative limit = 9.89689e-05, conv = true
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3288.25, relative limit = 0.0317863, conv = false
-(0) 16:21:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.364858, relative limit = 9.86271e-05, conv = false
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2802.88, relative limit = 0.00990207, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0825447, relative limit = 9.95691e-05, conv = false
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 699.824, relative limit = 0.0165404, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00513699, relative limit = 9.88723e-05, conv = false
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 35.8604, relative limit = 0.0168674, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000778216, relative limit = 9.88404e-05, conv = false
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.16279, relative limit = 0.0169265, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.04488e-05, relative limit = 9.88346e-05, conv = true
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.3688, relative limit = 0.01693, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.77091e-06, relative limit = 9.88343e-05, conv = true
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0471803, relative limit = 0.0169296, conv = false
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.60675e-07, relative limit = 9.88343e-05, conv = true
-(0) 16:21:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00631037, relative limit = 0.0169296, conv = true
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.76762e-08, relative limit = 9.88343e-05, conv = true
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:56 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10116.8, relative limit = 0.0866609, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25566, relative limit = 0.000108849, conv = false
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11449.5, relative limit = 0.0308185, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.184156, relative limit = 9.7365e-05, conv = false
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1517.26, relative limit = 0.0170489, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0163557, relative limit = 9.87522e-05, conv = false
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 144.709, relative limit = 0.0161261, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000524166, relative limit = 9.8868e-05, conv = false
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.90634, relative limit = 0.0161511, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.23873e-05, relative limit = 9.88644e-05, conv = true
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.462858, relative limit = 0.0161479, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98414e-05, relative limit = 9.88648e-05, conv = true
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.216819, relative limit = 0.0161465, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.28391e-06, relative limit = 9.8865e-05, conv = true
-(0) 16:21:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0495761, relative limit = 0.0161468, conv = false
-(0) 16:21:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.39828e-07, relative limit = 9.8865e-05, conv = true
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00451776, relative limit = 0.0161467, conv = true
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32372e-08, relative limit = 9.8865e-05, conv = true
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17930.7, relative limit = 0.166332, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43735, relative limit = 0.000120309, conv = false
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19353, relative limit = 0.0296832, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.203463, relative limit = 9.73821e-05, conv = false
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1847.93, relative limit = 0.0152352, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00414472, relative limit = 9.90879e-05, conv = false
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.706, relative limit = 0.0153392, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106168, relative limit = 9.90601e-05, conv = false
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.857157, relative limit = 0.0153446, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.03517e-05, relative limit = 9.90598e-05, conv = true
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.265477, relative limit = 0.0153459, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.05987e-05, relative limit = 9.90596e-05, conv = true
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0893849, relative limit = 0.0153455, conv = false
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11862e-07, relative limit = 9.90596e-05, conv = true
-(0) 16:21:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00148032, relative limit = 0.0153455, conv = true
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.89432e-08, relative limit = 9.90597e-05, conv = true
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24217, relative limit = 0.232307, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55885, relative limit = 0.000131407, conv = false
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25020.2, relative limit = 0.0226865, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.143967, relative limit = 9.81582e-05, conv = false
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1329.54, relative limit = 0.0148254, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00728238, relative limit = 9.94538e-05, conv = false
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 55.6744, relative limit = 0.014841, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00063336, relative limit = 9.94059e-05, conv = false
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.21507, relative limit = 0.0148501, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49048e-05, relative limit = 9.94011e-05, conv = true
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.23491, relative limit = 0.0148504, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7205e-06, relative limit = 9.94008e-05, conv = true
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0216451, relative limit = 0.0148503, conv = false
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.96605e-07, relative limit = 9.94009e-05, conv = true
-(0) 16:21:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00136171, relative limit = 0.0148503, conv = true
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.78044e-08, relative limit = 9.94009e-05, conv = true
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:21:59 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28203.8, relative limit = 0.276259, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36813, relative limit = 0.000139819, conv = false
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27326.9, relative limit = 0.0212985, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.104473, relative limit = 0.000100097, conv = false
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 720.167, relative limit = 0.0150154, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00697879, relative limit = 9.99092e-05, conv = false
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 62.605, relative limit = 0.0148484, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000604269, relative limit = 9.98533e-05, conv = false
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.10088, relative limit = 0.0148719, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000121055, relative limit = 9.9857e-05, conv = false
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06047, relative limit = 0.0148747, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.74725e-06, relative limit = 9.98559e-05, conv = true
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0584573, relative limit = 0.0148744, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09093e-06, relative limit = 9.98559e-05, conv = true
-(0) 16:22:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0148838, relative limit = 0.0148744, conv = false
-(0) 16:22:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.24865e-07, relative limit = 9.98559e-05, conv = true
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00341797, relative limit = 0.0148744, conv = true
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.60429e-08, relative limit = 9.98559e-05, conv = true
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29435.8, relative limit = 0.29321, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64037, relative limit = 0.000143322, conv = false
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27773.3, relative limit = 0.0271975, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180075, relative limit = 0.000101454, conv = false
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1439.95, relative limit = 0.0151582, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00477429, relative limit = 0.000100349, conv = false
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 49.8318, relative limit = 0.0154193, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00154615, relative limit = 0.000100394, conv = false
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.5011, relative limit = 0.0153993, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000256003, relative limit = 0.000100382, conv = false
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74989, relative limit = 0.0153936, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27764e-05, relative limit = 0.00010038, conv = true
-(0) 16:22:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.414015, relative limit = 0.0153917, conv = false
-(0) 16:22:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.76915e-06, relative limit = 0.00010038, conv = true
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0250302, relative limit = 0.0153916, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.56695e-07, relative limit = 0.00010038, conv = true
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00729339, relative limit = 0.0153916, conv = true
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50811e-08, relative limit = 0.00010038, conv = true
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27761.2, relative limit = 0.28118, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29007, relative limit = 0.000140971, conv = false
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25081.8, relative limit = 0.0389096, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.31242, relative limit = 0.000103155, conv = false
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2615.13, relative limit = 0.0150998, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0180292, relative limit = 0.000100777, conv = false
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 143.426, relative limit = 0.0161044, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000858246, relative limit = 0.000100915, conv = false
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.15573, relative limit = 0.0161796, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000301271, relative limit = 0.000100922, conv = false
-(0) 16:22:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.36428, relative limit = 0.016163, conv = false
-(0) 16:22:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.00879e-05, relative limit = 0.00010092, conv = true
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122006, relative limit = 0.0161622, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.14694e-06, relative limit = 0.00010092, conv = true
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0522091, relative limit = 0.0161619, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.5768e-08, relative limit = 0.00010092, conv = true
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000945208, relative limit = 0.0161619, conv = true
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.09621e-08, relative limit = 0.00010092, conv = true
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23349.4, relative limit = 0.24137, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42214, relative limit = 0.000133633, conv = false
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20060.9, relative limit = 0.0469683, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.393162, relative limit = 0.000104504, conv = false
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2433.34, relative limit = 0.0233029, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0847635, relative limit = 0.000102075, conv = false
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 569.399, relative limit = 0.0179873, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149424, relative limit = 0.000101536, conv = false
-(0) 16:22:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 116.94, relative limit = 0.0169301, conv = false
-(0) 16:22:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000717287, relative limit = 0.000101426, conv = false
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.38391, relative limit = 0.0168726, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.21889e-05, relative limit = 0.000101421, conv = true
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.641228, relative limit = 0.0168782, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.54118e-06, relative limit = 0.000101421, conv = true
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0417486, relative limit = 0.0168785, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.1405e-07, relative limit = 0.000101421, conv = true
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00470566, relative limit = 0.0168785, conv = true
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02639e-07, relative limit = 0.000101421, conv = true
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16688.5, relative limit = 0.178133, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26762, relative limit = 0.000123381, conv = false
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13667.5, relative limit = 0.0462535, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.367032, relative limit = 0.000104839, conv = false
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2929.89, relative limit = 0.0174661, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00535577, relative limit = 0.000101836, conv = false
-(0) 16:22:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 50.4127, relative limit = 0.0170978, conv = false
-(0) 16:22:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00249983, relative limit = 0.000101813, conv = false
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.202, relative limit = 0.0172613, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000427394, relative limit = 0.00010183, conv = false
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06288, relative limit = 0.0172904, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.66538e-05, relative limit = 0.000101833, conv = true
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.477938, relative limit = 0.017295, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12195e-06, relative limit = 0.000101833, conv = true
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0051919, relative limit = 0.017295, conv = true
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.20163e-07, relative limit = 0.000101833, conv = true
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8647.16, relative limit = 0.0992111, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08075, relative limit = 0.000112382, conv = false
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7106.41, relative limit = 0.0313299, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.17211, relative limit = 0.000103615, conv = false
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1172.53, relative limit = 0.0197009, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0297327, relative limit = 0.000102367, conv = false
-(0) 16:22:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 258.332, relative limit = 0.0171707, conv = false
-(0) 16:22:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00143299, relative limit = 0.000102103, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.4434, relative limit = 0.0173499, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000849029, relative limit = 0.000102122, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.02245, relative limit = 0.0172814, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.271e-06, relative limit = 0.000102115, conv = true
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0622542, relative limit = 0.0172808, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94334e-06, relative limit = 0.000102115, conv = true
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0132384, relative limit = 0.0172807, conv = true
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.95168e-07, relative limit = 0.000102115, conv = true
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3463.03, relative limit = 0.0315301, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394871, relative limit = 0.00010218, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3046.49, relative limit = 0.0206295, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0475147, relative limit = 0.000102654, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 398.943, relative limit = 0.0166595, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0052836, relative limit = 0.000102219, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 40.8979, relative limit = 0.0168322, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00014562, relative limit = 0.000102239, conv = false
-(0) 16:22:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66457, relative limit = 0.0168458, conv = false
-(0) 16:22:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000110056, relative limit = 0.00010224, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.758232, relative limit = 0.0168383, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89627e-05, relative limit = 0.00010224, conv = true
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.154978, relative limit = 0.0168368, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.95231e-07, relative limit = 0.000102239, conv = true
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00257994, relative limit = 0.0168368, conv = true
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32078e-07, relative limit = 0.000102239, conv = true
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10575.1, relative limit = 0.0914529, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09256, relative limit = 9.35841e-05, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8766.64, relative limit = 0.00976128, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.175064, relative limit = 0.00010071, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1468.17, relative limit = 0.0158796, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00462596, relative limit = 0.000102164, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 45.3605, relative limit = 0.0161379, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00087673, relative limit = 0.000102201, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.10466, relative limit = 0.0161026, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000138157, relative limit = 0.000102196, conv = false
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.885029, relative limit = 0.0160986, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.8599e-05, relative limit = 0.000102195, conv = true
-(0) 16:22:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.194449, relative limit = 0.0160976, conv = false
-(0) 16:22:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.58579e-06, relative limit = 0.000102195, conv = true
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0409741, relative limit = 0.0160974, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59182e-07, relative limit = 0.000102195, conv = true
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00379089, relative limit = 0.0160975, conv = true
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.52803e-09, relative limit = 0.000102195, conv = true
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18246.6, relative limit = 0.169806, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76027, relative limit = 8.6876e-05, conv = false
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16803.5, relative limit = 0.01184, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122281, relative limit = 0.000100921, conv = false
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1158.76, relative limit = 0.0157655, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0126501, relative limit = 0.000102082, conv = false
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 106.316, relative limit = 0.0153149, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.93387e-05, relative limit = 0.000101989, conv = true
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18761, relative limit = 0.0153147, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.39006e-05, relative limit = 0.000101988, conv = true
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.930261, relative limit = 0.0153179, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.75197e-05, relative limit = 0.000101989, conv = true
-(0) 16:22:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.340647, relative limit = 0.0153165, conv = false
-(0) 16:22:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.69175e-06, relative limit = 0.000101989, conv = true
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0204915, relative limit = 0.0153166, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.56545e-07, relative limit = 0.000101989, conv = true
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0021351, relative limit = 0.0153166, conv = true
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13095e-08, relative limit = 0.000101989, conv = true
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24268.6, relative limit = 0.233235, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22205, relative limit = 8.20612e-05, conv = false
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23386.7, relative limit = 0.0130927, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0498023, relative limit = 0.000101186, conv = false
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 411.235, relative limit = 0.0147332, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00190331, relative limit = 0.000101625, conv = false
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 14.844, relative limit = 0.0148074, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000150761, relative limit = 0.00010164, conv = false
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12301, relative limit = 0.014809, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75226e-05, relative limit = 0.000101641, conv = true
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.13362, relative limit = 0.014809, conv = false
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86004e-06, relative limit = 0.000101641, conv = true
-(0) 16:22:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0120248, relative limit = 0.014809, conv = true
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14046e-07, relative limit = 0.000101641, conv = true
-(0) 16:22:09 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27976, relative limit = 0.274475, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47818, relative limit = 7.90494e-05, conv = false
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28483.9, relative limit = 0.0146593, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.135251, relative limit = 0.000102055, conv = false
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1164.73, relative limit = 0.0148412, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00366483, relative limit = 0.000101158, conv = false
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 33.7309, relative limit = 0.0148164, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000274616, relative limit = 0.000101191, conv = false
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01601, relative limit = 0.0148144, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.13478e-05, relative limit = 0.000101189, conv = true
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.431834, relative limit = 0.0148149, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.27852e-06, relative limit = 0.000101189, conv = true
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0375114, relative limit = 0.0148149, conv = false
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42821e-06, relative limit = 0.000101189, conv = true
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00902057, relative limit = 0.0148148, conv = true
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63883e-07, relative limit = 0.000101189, conv = true
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29019.5, relative limit = 0.289577, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53924, relative limit = 7.77571e-05, conv = false
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29767.9, relative limit = 0.0128617, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.16107, relative limit = 0.000101795, conv = false
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1276.56, relative limit = 0.0147658, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0112893, relative limit = 0.000100753, conv = false
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 100.1, relative limit = 0.0153595, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000235612, relative limit = 0.000100672, conv = false
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82035, relative limit = 0.0153485, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.88042e-05, relative limit = 0.000100674, conv = true
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.372656, relative limit = 0.0153464, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56443e-05, relative limit = 0.000100674, conv = true
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.108835, relative limit = 0.015347, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15189e-06, relative limit = 0.000100674, conv = true
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0261171, relative limit = 0.0153471, conv = false
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67929e-07, relative limit = 0.000100674, conv = true
-(0) 16:22:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000935233, relative limit = 0.0153471, conv = true
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.00308e-08, relative limit = 0.000100674, conv = true
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27317.9, relative limit = 0.277251, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41255, relative limit = 7.8159e-05, conv = false
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28029.6, relative limit = 0.0102083, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.146524, relative limit = 0.000101243, conv = false
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1139.86, relative limit = 0.0151569, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0156603, relative limit = 0.000100266, conv = false
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 132.189, relative limit = 0.01613, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00067971, relative limit = 0.000100151, conv = false
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27593, relative limit = 0.0161706, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.60053e-05, relative limit = 0.000100147, conv = true
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.758213, relative limit = 0.0161757, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31422e-05, relative limit = 0.000100147, conv = true
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.105207, relative limit = 0.0161752, conv = false
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.49461e-06, relative limit = 0.000100147, conv = true
-(0) 16:22:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0134152, relative limit = 0.0161751, conv = true
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.22907e-08, relative limit = 0.000100147, conv = true
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:12 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23048.8, relative limit = 0.238791, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09892, relative limit = 8.03094e-05, conv = false
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24109.3, relative limit = 0.00826114, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.1744, relative limit = 0.000101066, conv = false
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1542.75, relative limit = 0.0170667, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00150345, relative limit = 9.96518e-05, conv = false
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.5567, relative limit = 0.0169855, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000276863, relative limit = 9.96545e-05, conv = false
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1613, relative limit = 0.0169673, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09894e-05, relative limit = 9.96563e-05, conv = true
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.248542, relative limit = 0.0169652, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.24618e-06, relative limit = 9.96565e-05, conv = true
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0249834, relative limit = 0.016965, conv = false
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.83888e-07, relative limit = 9.96565e-05, conv = true
-(0) 16:22:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00437367, relative limit = 0.016965, conv = true
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.39243e-08, relative limit = 9.96565e-05, conv = true
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:13 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16641.3, relative limit = 0.177994, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59432, relative limit = 8.43392e-05, conv = false
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17764.1, relative limit = 0.00544489, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.17307, relative limit = 0.000100657, conv = false
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1529, relative limit = 0.0174818, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00128688, relative limit = 9.92483e-05, conv = false
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.41642, relative limit = 0.0174383, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000273781, relative limit = 9.92499e-05, conv = false
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09531, relative limit = 0.0174319, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09311e-05, relative limit = 9.92498e-05, conv = true
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.256078, relative limit = 0.0174323, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.03299e-06, relative limit = 9.92497e-05, conv = true
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0402457, relative limit = 0.0174326, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.44024e-07, relative limit = 9.92497e-05, conv = true
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00551464, relative limit = 0.0174327, conv = true
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.58023e-08, relative limit = 9.92497e-05, conv = true
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8845.09, relative limit = 0.101503, conv = false
-(0) 16:22:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.90527, relative limit = 9.04178e-05, conv = false
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9559.68, relative limit = 0.00737698, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.119541, relative limit = 9.9975e-05, conv = false
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 992.65, relative limit = 0.016767, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00762473, relative limit = 9.90298e-05, conv = false
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 67.2022, relative limit = 0.0174128, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000271969, relative limit = 9.89667e-05, conv = false
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.15981, relative limit = 0.0174247, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.18933e-05, relative limit = 9.89653e-05, conv = true
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.263391, relative limit = 0.0174257, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.45306e-06, relative limit = 9.89652e-05, conv = true
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0259615, relative limit = 0.0174256, conv = false
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.49887e-07, relative limit = 9.89652e-05, conv = true
-(0) 16:22:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00468133, relative limit = 0.0174256, conv = true
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35957e-07, relative limit = 9.89652e-05, conv = true
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:15 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.36, relative limit = 0.0317005, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365129, relative limit = 9.86503e-05, conv = false
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2841.18, relative limit = 0.0112215, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0659538, relative limit = 9.94269e-05, conv = false
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 529.559, relative limit = 0.0163906, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00658737, relative limit = 9.8888e-05, conv = false
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 48.2465, relative limit = 0.016863, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00101058, relative limit = 9.88399e-05, conv = false
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.91087, relative limit = 0.0169412, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.72831e-05, relative limit = 9.88321e-05, conv = true
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.7814, relative limit = 0.0169489, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.70424e-06, relative limit = 9.88314e-05, conv = true
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0628729, relative limit = 0.0169494, conv = false
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.34137e-07, relative limit = 9.88313e-05, conv = true
-(0) 16:22:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00312503, relative limit = 0.0169495, conv = true
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03958e-08, relative limit = 9.88313e-05, conv = true
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:16 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10133.6, relative limit = 0.0868091, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25792, relative limit = 0.00010887, conv = false
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11442.5, relative limit = 0.030554, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.181592, relative limit = 9.73907e-05, conv = false
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1524.81, relative limit = 0.0168566, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0123983, relative limit = 9.87762e-05, conv = false
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 124.653, relative limit = 0.0160723, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00215862, relative limit = 9.88758e-05, conv = false
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.2232, relative limit = 0.0161831, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000372326, relative limit = 9.88602e-05, conv = false
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.73764, relative limit = 0.0161686, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.69663e-05, relative limit = 9.88622e-05, conv = true
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.397461, relative limit = 0.0161663, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.54736e-07, relative limit = 9.88625e-05, conv = true
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00311781, relative limit = 0.0161662, conv = true
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18284e-07, relative limit = 9.88625e-05, conv = true
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17944.9, relative limit = 0.166456, conv = false
-(0) 16:22:17 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43955, relative limit = 0.000120329, conv = false
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19318.4, relative limit = 0.0293156, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.19787, relative limit = 9.7419e-05, conv = false
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1691.94, relative limit = 0.0156803, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0087504, relative limit = 9.89942e-05, conv = false
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 78.9929, relative limit = 0.0153527, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00051372, relative limit = 9.90607e-05, conv = false
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.0318, relative limit = 0.0153654, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.86877e-05, relative limit = 9.90569e-05, conv = true
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.82254, relative limit = 0.0153622, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21756e-06, relative limit = 9.90576e-05, conv = true
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00669817, relative limit = 0.0153622, conv = true
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02325e-06, relative limit = 9.90576e-05, conv = true
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24228.6, relative limit = 0.232407, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.5609, relative limit = 0.000131425, conv = false
-(0) 16:22:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25088.8, relative limit = 0.023061, conv = false
-(0) 16:22:18 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.150505, relative limit = 9.81061e-05, conv = false
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1428.4, relative limit = 0.0147694, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0119935, relative limit = 9.94904e-05, conv = false
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 98.7228, relative limit = 0.0148479, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000375618, relative limit = 9.94025e-05, conv = false
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.68223, relative limit = 0.0148615, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.66096e-05, relative limit = 9.93997e-05, conv = true
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.59192, relative limit = 0.0148622, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.09514e-06, relative limit = 9.93992e-05, conv = true
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0603464, relative limit = 0.0148624, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.17262e-07, relative limit = 9.93991e-05, conv = true
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0019174, relative limit = 0.0148624, conv = true
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47377e-07, relative limit = 9.93991e-05, conv = true
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.3, relative limit = 0.27634, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36995, relative limit = 0.000139835, conv = false
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28578.6, relative limit = 0.0189749, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103466, relative limit = 9.89274e-05, conv = false
-(0) 16:22:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 946.554, relative limit = 0.0150045, conv = false
-(0) 16:22:19 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00619205, relative limit = 9.9902e-05, conv = false
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 45.6101, relative limit = 0.0149009, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000788739, relative limit = 9.986e-05, conv = false
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.6417, relative limit = 0.0148796, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.27248e-05, relative limit = 9.98544e-05, conv = true
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.323842, relative limit = 0.0148814, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32238e-05, relative limit = 9.98546e-05, conv = true
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.192556, relative limit = 0.0148811, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.06114e-07, relative limit = 9.98544e-05, conv = true
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00731965, relative limit = 0.0148811, conv = true
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66654e-07, relative limit = 9.98544e-05, conv = true
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.5, relative limit = 0.293276, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64191, relative limit = 0.000143336, conv = false
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27680.7, relative limit = 0.0285309, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.197951, relative limit = 0.000101541, conv = false
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1539.89, relative limit = 0.015467, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00260415, relative limit = 0.000100364, conv = false
-(0) 16:22:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.5455, relative limit = 0.0152306, conv = false
-(0) 16:22:20 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00372577, relative limit = 0.00010035, conv = false
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.0423, relative limit = 0.0153839, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000233202, relative limit = 0.000100377, conv = false
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47751, relative limit = 0.0153914, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.41052e-05, relative limit = 0.000100378, conv = true
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.320519, relative limit = 0.0153931, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.573e-05, relative limit = 0.000100378, conv = true
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.128802, relative limit = 0.0153937, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.36891e-07, relative limit = 0.000100378, conv = true
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00830216, relative limit = 0.0153937, conv = true
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.83773e-07, relative limit = 0.000100378, conv = true
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.7, relative limit = 0.281235, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29132, relative limit = 0.000140982, conv = false
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25513.1, relative limit = 0.0342668, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.249268, relative limit = 0.000102699, conv = false
-(0) 16:22:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2108.15, relative limit = 0.0152754, conv = false
-(0) 16:22:21 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0152214, relative limit = 0.000100797, conv = false
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 234.075, relative limit = 0.0169206, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0128118, relative limit = 0.000101025, conv = false
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 89.9562, relative limit = 0.016284, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00207033, relative limit = 0.000100935, conv = false
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.0116, relative limit = 0.0161623, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1279e-05, relative limit = 0.000100919, conv = true
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.352831, relative limit = 0.01616, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0513e-05, relative limit = 0.000100919, conv = true
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0959922, relative limit = 0.0161606, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.86825e-07, relative limit = 0.000100919, conv = true
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00886862, relative limit = 0.0161606, conv = true
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.60743e-07, relative limit = 0.000100919, conv = true
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355, relative limit = 0.241417, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42312, relative limit = 0.000133641, conv = false
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20584.7, relative limit = 0.0412985, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.318504, relative limit = 0.00010392, conv = false
-(0) 16:22:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2302.15, relative limit = 0.019128, conv = false
-(0) 16:22:22 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0302063, relative limit = 0.000101657, conv = false
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 260.564, relative limit = 0.0167736, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00152303, relative limit = 0.000101408, conv = false
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4429, relative limit = 0.0168041, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000975661, relative limit = 0.000101413, conv = false
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.00355, relative limit = 0.0168761, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27474e-05, relative limit = 0.00010142, conv = true
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.233525, relative limit = 0.0168758, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.93266e-06, relative limit = 0.00010142, conv = true
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0748654, relative limit = 0.0168752, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.28172e-07, relative limit = 0.00010142, conv = true
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000731221, relative limit = 0.0168752, conv = true
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.61937e-08, relative limit = 0.00010142, conv = true
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178175, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26839, relative limit = 0.000123387, conv = false
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13793.2, relative limit = 0.0449312, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.349948, relative limit = 0.000104697, conv = false
-(0) 16:22:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2342.47, relative limit = 0.0218396, conv = false
-(0) 16:22:23 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0572314, relative limit = 0.000102294, conv = false
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 446.877, relative limit = 0.0175229, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00298564, relative limit = 0.000101856, conv = false
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23.5805, relative limit = 0.0172991, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000118938, relative limit = 0.000101833, conv = false
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.904167, relative limit = 0.017291, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.65236e-06, relative limit = 0.000101833, conv = true
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.106918, relative limit = 0.0172903, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11179e-06, relative limit = 0.000101832, conv = true
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0223278, relative limit = 0.0172904, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.27023e-07, relative limit = 0.000101832, conv = true
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00459269, relative limit = 0.0172905, conv = true
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.13041e-08, relative limit = 0.000101833, conv = true
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.46, relative limit = 0.0992486, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08132, relative limit = 0.000112386, conv = false
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7061.01, relative limit = 0.0325008, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.187717, relative limit = 0.000103704, conv = false
-(0) 16:22:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1385.19, relative limit = 0.0188069, conv = false
-(0) 16:22:24 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0188169, relative limit = 0.000102272, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 108.532, relative limit = 0.0177458, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00576281, relative limit = 0.000102163, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 44.509, relative limit = 0.0173101, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000422051, relative limit = 0.000102118, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.26706, relative limit = 0.0172782, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06142e-05, relative limit = 0.000102115, conv = true
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.205373, relative limit = 0.0172763, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.03961e-06, relative limit = 0.000102114, conv = true
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0556473, relative limit = 0.0172758, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.84703e-07, relative limit = 0.000102114, conv = true
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00325535, relative limit = 0.0172758, conv = true
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13021e-07, relative limit = 0.000102114, conv = true
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.55, relative limit = 0.0315334, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394729, relative limit = 0.000102184, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3181.6, relative limit = 0.0221171, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0644654, relative limit = 0.000102809, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 408.636, relative limit = 0.0180405, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149347, relative limit = 0.00010237, conv = false
-(0) 16:22:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 120.912, relative limit = 0.0168717, conv = false
-(0) 16:22:25 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000515086, relative limit = 0.000102243, conv = false
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.77738, relative limit = 0.0168172, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0001804, relative limit = 0.000102237, conv = false
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.53515, relative limit = 0.0168323, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.23938e-06, relative limit = 0.000102239, conv = true
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0564931, relative limit = 0.0168318, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37426e-06, relative limit = 0.000102239, conv = true
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00935459, relative limit = 0.0168318, conv = true
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47797e-07, relative limit = 0.000102239, conv = true
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914183, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09218, relative limit = 9.35871e-05, conv = false
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8783.03, relative limit = 0.00966598, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.172806, relative limit = 0.000100727, conv = false
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1422.28, relative limit = 0.0156883, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0077639, relative limit = 0.000102137, conv = false
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 64.3906, relative limit = 0.0160871, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.89383e-05, relative limit = 0.000102194, conv = true
-(0) 16:22:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72904, relative limit = 0.0161064, conv = false
-(0) 16:22:26 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000289833, relative limit = 0.000102196, conv = false
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98193, relative limit = 0.0160948, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9779e-05, relative limit = 0.000102195, conv = true
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.486005, relative limit = 0.0160921, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.53389e-06, relative limit = 0.000102194, conv = true
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.070741, relative limit = 0.0160926, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02122e-06, relative limit = 0.000102195, conv = true
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00665987, relative limit = 0.0160926, conv = true
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17796e-07, relative limit = 0.000102195, conv = true
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.8, relative limit = 0.169772, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16939.9, relative limit = 0.0113271, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.10699, relative limit = 0.000101041, conv = false
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 811.545, relative limit = 0.014844, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0135903, relative limit = 0.000101883, conv = false
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 112.331, relative limit = 0.0152977, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000383109, relative limit = 0.000101985, conv = false
-(0) 16:22:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.94059, relative limit = 0.0153146, conv = false
-(0) 16:22:27 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.39036e-05, relative limit = 0.000101989, conv = true
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.729126, relative limit = 0.015312, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.82546e-06, relative limit = 0.000101988, conv = true
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0104172, relative limit = 0.0153121, conv = true
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04896e-06, relative limit = 0.000101988, conv = true
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265.1, relative limit = 0.233204, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22178, relative limit = 8.20632e-05, conv = false
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23373.4, relative limit = 0.0131094, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0508066, relative limit = 0.000101176, conv = false
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 444.372, relative limit = 0.0147804, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00144605, relative limit = 0.000101648, conv = false
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.0661, relative limit = 0.0148052, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.02893e-05, relative limit = 0.000101641, conv = true
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.337685, relative limit = 0.0148054, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02753e-05, relative limit = 0.000101641, conv = true
-(0) 16:22:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0690879, relative limit = 0.0148053, conv = false
-(0) 16:22:28 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.13729e-06, relative limit = 0.000101641, conv = true
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0160148, relative limit = 0.0148053, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66238e-07, relative limit = 0.000101641, conv = true
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00188088, relative limit = 0.0148053, conv = true
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46349e-08, relative limit = 0.000101641, conv = true
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28162.8, relative limit = 0.0135027, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0955671, relative limit = 0.000101775, conv = false
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 904.845, relative limit = 0.0150867, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0125219, relative limit = 0.000101096, conv = false
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 109.535, relative limit = 0.0148181, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000356394, relative limit = 0.000101191, conv = false
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.3726, relative limit = 0.0148126, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07971e-05, relative limit = 0.000101189, conv = true
-(0) 16:22:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.715895, relative limit = 0.0148122, conv = false
-(0) 16:22:29 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00968e-05, relative limit = 0.000101188, conv = true
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0806417, relative limit = 0.0148122, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50444e-06, relative limit = 0.000101188, conv = true
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0137648, relative limit = 0.0148122, conv = true
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35666e-07, relative limit = 0.000101188, conv = true
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.7, relative limit = 0.289551, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53904, relative limit = 7.77586e-05, conv = false
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29288.7, relative limit = 0.0119449, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102303, relative limit = 0.000101365, conv = false
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 890.405, relative limit = 0.0152961, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00262658, relative limit = 0.000100652, conv = false
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.0922, relative limit = 0.0153222, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000330221, relative limit = 0.000100674, conv = false
-(0) 16:22:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06314, relative limit = 0.0153406, conv = false
-(0) 16:22:30 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.63589e-05, relative limit = 0.000100674, conv = true
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.701646, relative limit = 0.0153453, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76982e-06, relative limit = 0.000100674, conv = true
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0425897, relative limit = 0.0153455, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.58058e-07, relative limit = 0.000100674, conv = true
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00227687, relative limit = 0.0153455, conv = true
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03077e-08, relative limit = 0.000100674, conv = true
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28009.7, relative limit = 0.00993351, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.145537, relative limit = 0.000101214, conv = false
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1281.27, relative limit = 0.0162739, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00238994, relative limit = 0.000100126, conv = false
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19.2303, relative limit = 0.016176, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000327667, relative limit = 0.000100145, conv = false
-(0) 16:22:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7624, relative limit = 0.0161719, conv = false
-(0) 16:22:31 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.60895e-05, relative limit = 0.000100147, conv = true
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.392745, relative limit = 0.0161744, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21069e-06, relative limit = 0.000100146, conv = true
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0139316, relative limit = 0.0161745, conv = true
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87095e-06, relative limit = 0.000100146, conv = true
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.8, relative limit = 0.238772, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09876, relative limit = 8.03106e-05, conv = false
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23963.7, relative limit = 0.00745901, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.162145, relative limit = 0.000100894, conv = false
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1245.03, relative limit = 0.015449, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0193894, relative limit = 9.98072e-05, conv = false
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 171.353, relative limit = 0.0169524, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000189575, relative limit = 9.96567e-05, conv = false
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.30629, relative limit = 0.0169631, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61929e-05, relative limit = 9.96564e-05, conv = true
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.212048, relative limit = 0.016965, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.4371e-06, relative limit = 9.96563e-05, conv = true
-(0) 16:22:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0308893, relative limit = 0.0169652, conv = false
-(0) 16:22:32 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21367e-06, relative limit = 9.96563e-05, conv = true
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00913197, relative limit = 0.0169651, conv = true
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.6125e-07, relative limit = 9.96563e-05, conv = true
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.6, relative limit = 0.177979, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59417, relative limit = 8.43403e-05, conv = false
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17535.3, relative limit = 0.00650628, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.146136, relative limit = 0.000100432, conv = false
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1178.88, relative limit = 0.0163511, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0127501, relative limit = 9.93541e-05, conv = false
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 111.773, relative limit = 0.0174106, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000318598, relative limit = 9.92511e-05, conv = false
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21363, relative limit = 0.0174255, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.35467e-05, relative limit = 9.92502e-05, conv = true
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.764378, relative limit = 0.0174326, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.22604e-06, relative limit = 9.92495e-05, conv = true
-(0) 16:22:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0813337, relative limit = 0.0174333, conv = false
-(0) 16:22:33 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.73498e-07, relative limit = 9.92495e-05, conv = true
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00432554, relative limit = 0.0174333, conv = true
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68283e-08, relative limit = 9.92495e-05, conv = true
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.76, relative limit = 0.101491, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905141, relative limit = 9.04188e-05, conv = false
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9591.1, relative limit = 0.00710835, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.123707, relative limit = 0.000100011, conv = false
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 930.389, relative limit = 0.0157864, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0187613, relative limit = 9.91243e-05, conv = false
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 165.992, relative limit = 0.0174035, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000273501, relative limit = 9.89672e-05, conv = false
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32231, relative limit = 0.0174249, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87102e-05, relative limit = 9.89651e-05, conv = true
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.124233, relative limit = 0.017426, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.20987e-06, relative limit = 9.89651e-05, conv = true
-(0) 16:22:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0444236, relative limit = 0.0174264, conv = false
-(0) 16:22:34 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14966e-07, relative limit = 9.8965e-05, conv = true
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00347861, relative limit = 0.0174264, conv = true
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.27642e-08, relative limit = 9.8965e-05, conv = true
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.43, relative limit = 0.031697, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365143, relative limit = 9.86513e-05, conv = false
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2841.95, relative limit = 0.0122604, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0536594, relative limit = 9.93107e-05, conv = false
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 470.205, relative limit = 0.0169215, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000768161, relative limit = 9.88336e-05, conv = false
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.26883, relative limit = 0.0169191, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000374345, relative limit = 9.88343e-05, conv = false
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.60885, relative limit = 0.0169445, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.96181e-05, relative limit = 9.88317e-05, conv = true
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.654463, relative limit = 0.016951, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.48326e-06, relative limit = 9.88311e-05, conv = true
-(0) 16:22:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0531576, relative limit = 0.0169505, conv = false
-(0) 16:22:35 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2397e-07, relative limit = 9.88312e-05, conv = true
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00074714, relative limit = 0.0169505, conv = true
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.43708e-08, relative limit = 9.88312e-05, conv = true
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.4, relative limit = 0.0868156, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25802, relative limit = 0.000108871, conv = false
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11437.4, relative limit = 0.0304866, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180973, relative limit = 9.7398e-05, conv = false
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1475.28, relative limit = 0.0171431, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177103, relative limit = 9.87396e-05, conv = false
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 163.944, relative limit = 0.0161081, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00147597, relative limit = 9.88707e-05, conv = false
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.4572, relative limit = 0.0161707, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59391e-05, relative limit = 9.8862e-05, conv = true
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.454782, relative limit = 0.0161667, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.01127e-05, relative limit = 9.88624e-05, conv = true
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102303, relative limit = 0.0161661, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17953e-05, relative limit = 9.88625e-05, conv = true
-(0) 16:22:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.186763, relative limit = 0.0161673, conv = false
-(0) 16:22:36 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.1547e-07, relative limit = 9.88624e-05, conv = true
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00225514, relative limit = 0.0161673, conv = true
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65302e-07, relative limit = 9.88624e-05, conv = true
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17945.5, relative limit = 0.166461, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43965, relative limit = 0.00012033, conv = false
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19321.6, relative limit = 0.0293372, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.198158, relative limit = 9.74165e-05, conv = false
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1733.29, relative limit = 0.0155069, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00412816, relative limit = 9.90281e-05, conv = false
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.1334, relative limit = 0.0153201, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00139175, relative limit = 9.90672e-05, conv = false
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.6197, relative limit = 0.015365, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00010004, relative limit = 9.90569e-05, conv = false
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.707521, relative limit = 0.0153636, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.4912e-05, relative limit = 9.90574e-05, conv = true
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.12354, relative limit = 0.0153631, conv = false
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.71073e-07, relative limit = 9.90575e-05, conv = true
-(0) 16:22:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00112378, relative limit = 0.0153631, conv = true
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.87179e-07, relative limit = 9.90575e-05, conv = true
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:37 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24229.1, relative limit = 0.232411, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56098, relative limit = 0.000131426, conv = false
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25043.7, relative limit = 0.0227545, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.145344, relative limit = 9.81474e-05, conv = false
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1310.2, relative limit = 0.0147969, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00311566, relative limit = 9.9425e-05, conv = false
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28.1931, relative limit = 0.0148696, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000156813, relative limit = 9.93976e-05, conv = false
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.16732, relative limit = 0.014862, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.59954e-05, relative limit = 9.93998e-05, conv = true
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.910998, relative limit = 0.0148632, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10442e-05, relative limit = 9.93989e-05, conv = true
-(0) 16:22:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0818878, relative limit = 0.0148631, conv = false
-(0) 16:22:38 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3573e-06, relative limit = 9.9399e-05, conv = true
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0115552, relative limit = 0.0148631, conv = true
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89743e-08, relative limit = 9.9399e-05, conv = true
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.6, relative limit = 0.276342, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.37001, relative limit = 0.000139836, conv = false
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27511.3, relative limit = 0.020454, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.08535, relative limit = 9.99219e-05, conv = false
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 505.388, relative limit = 0.0156873, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0198357, relative limit = 9.99696e-05, conv = false
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 142.157, relative limit = 0.0148758, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00237361, relative limit = 9.98752e-05, conv = false
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.479, relative limit = 0.0148818, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.798e-05, relative limit = 9.98545e-05, conv = true
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.373842, relative limit = 0.0148816, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.86262e-05, relative limit = 9.98546e-05, conv = true
-(0) 16:22:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.346996, relative limit = 0.0148816, conv = false
-(0) 16:22:39 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44735e-06, relative limit = 9.98543e-05, conv = true
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0123028, relative limit = 0.0148816, conv = true
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40011e-07, relative limit = 9.98543e-05, conv = true
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.8, relative limit = 0.293277, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64195, relative limit = 0.000143336, conv = false
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27733.1, relative limit = 0.0282454, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.192623, relative limit = 0.00010148, conv = false
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1338.28, relative limit = 0.0165308, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0196437, relative limit = 0.000100499, conv = false
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 141.589, relative limit = 0.0154558, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00211405, relative limit = 0.000100397, conv = false
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.6948, relative limit = 0.0153993, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000171069, relative limit = 0.00010038, conv = false
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.981399, relative limit = 0.0153956, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.61779e-05, relative limit = 0.000100379, conv = true
-(0) 16:22:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.442263, relative limit = 0.0153941, conv = false
-(0) 16:22:40 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.15114e-06, relative limit = 0.000100378, conv = true
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0358871, relative limit = 0.0153939, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.6911e-07, relative limit = 0.000100378, conv = true
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00523848, relative limit = 0.0153939, conv = true
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11275e-07, relative limit = 0.000100378, conv = true
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.9, relative limit = 0.281236, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29135, relative limit = 0.000140982, conv = false
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24779.3, relative limit = 0.0421959, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.356939, relative limit = 0.000103491, conv = false
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2536.17, relative limit = 0.018384, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0334444, relative limit = 0.000101166, conv = false
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 233.011, relative limit = 0.0164706, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00502066, relative limit = 0.000100956, conv = false
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.4562, relative limit = 0.0162079, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000758337, relative limit = 0.000100924, conv = false
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.47822, relative limit = 0.0161654, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35452e-05, relative limit = 0.000100919, conv = true
-(0) 16:22:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.707714, relative limit = 0.0161603, conv = false
-(0) 16:22:41 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.34728e-06, relative limit = 0.000100919, conv = true
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0373423, relative limit = 0.0161605, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88452e-06, relative limit = 0.000100919, conv = true
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0133246, relative limit = 0.0161606, conv = true
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86112e-07, relative limit = 0.000100919, conv = true
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355.2, relative limit = 0.241417, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42314, relative limit = 0.000133641, conv = false
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20283.1, relative limit = 0.0439114, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.352369, relative limit = 0.000104262, conv = false
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2774.27, relative limit = 0.0173835, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00812142, relative limit = 0.00010147, conv = false
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 80.6667, relative limit = 0.0166917, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00260502, relative limit = 0.000101405, conv = false
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.1517, relative limit = 0.0168727, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.16491e-05, relative limit = 0.00010142, conv = true
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.548064, relative limit = 0.0168776, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10696e-05, relative limit = 0.00010142, conv = true
-(0) 16:22:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.344439, relative limit = 0.0168751, conv = false
-(0) 16:22:42 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90958e-06, relative limit = 0.00010142, conv = true
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0162444, relative limit = 0.016875, conv = true
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9403e-08, relative limit = 0.00010142, conv = true
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178175, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.2684, relative limit = 0.000123387, conv = false
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13954.4, relative limit = 0.0427673, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.321392, relative limit = 0.000104501, conv = false
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2554.88, relative limit = 0.0177386, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00769094, relative limit = 0.000101857, conv = false
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 48.4417, relative limit = 0.0174707, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00248553, relative limit = 0.000101854, conv = false
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.8176, relative limit = 0.0172839, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103749, relative limit = 0.000101832, conv = false
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.862468, relative limit = 0.0172901, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.99365e-06, relative limit = 0.000101832, conv = true
-(0) 16:22:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0358609, relative limit = 0.0172898, conv = false
-(0) 16:22:43 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.00101e-06, relative limit = 0.000101832, conv = true
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0477237, relative limit = 0.0172901, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.2645e-07, relative limit = 0.000101832, conv = true
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00497253, relative limit = 0.0172902, conv = true
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.64993e-08, relative limit = 0.000101832, conv = true
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.53, relative limit = 0.0992488, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08133, relative limit = 0.000112386, conv = false
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6984.94, relative limit = 0.0327952, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.190294, relative limit = 0.000103774, conv = false
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1401.32, relative limit = 0.0189065, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0200521, relative limit = 0.000102287, conv = false
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 140.45, relative limit = 0.0175411, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00324763, relative limit = 0.000102142, conv = false
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.7349, relative limit = 0.017328, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000648293, relative limit = 0.00010212, conv = false
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.2428, relative limit = 0.017277, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35835e-05, relative limit = 0.000102115, conv = true
-(0) 16:22:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.187753, relative limit = 0.0172753, conv = false
-(0) 16:22:44 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.45005e-07, relative limit = 0.000102114, conv = true
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00359162, relative limit = 0.0172753, conv = true
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.67789e-08, relative limit = 0.000102114, conv = true
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.54, relative limit = 0.0315334, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394728, relative limit = 0.000102184, conv = false
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3159.67, relative limit = 0.0222344, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0654906, relative limit = 0.000102837, conv = false
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 514.564, relative limit = 0.0171354, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00537271, relative limit = 0.000102272, conv = false
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.3076, relative limit = 0.0167962, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000534955, relative limit = 0.000102234, conv = false
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.48801, relative limit = 0.0168304, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.39532e-05, relative limit = 0.000102239, conv = true
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.340412, relative limit = 0.0168331, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21158e-05, relative limit = 0.000102239, conv = true
-(0) 16:22:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.123641, relative limit = 0.0168319, conv = false
-(0) 16:22:45 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.24081e-06, relative limit = 0.000102239, conv = true
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0532008, relative limit = 0.0168314, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54534e-07, relative limit = 0.000102239, conv = true
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00519937, relative limit = 0.0168313, conv = true
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24689e-07, relative limit = 0.000102239, conv = true
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914182, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09217, relative limit = 9.35871e-05, conv = false
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8800.62, relative limit = 0.00976083, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.170563, relative limit = 0.000100751, conv = false
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1399.46, relative limit = 0.0157098, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00844864, relative limit = 0.000102137, conv = false
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 68.5825, relative limit = 0.0160882, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000146633, relative limit = 0.000102194, conv = false
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27675, relative limit = 0.0160926, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.68457e-05, relative limit = 0.000102195, conv = true
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0650567, relative limit = 0.0160926, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.21302e-06, relative limit = 0.000102195, conv = true
-(0) 16:22:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.07695, relative limit = 0.0160922, conv = false
-(0) 16:22:46 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.54522e-07, relative limit = 0.000102194, conv = true
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00144794, relative limit = 0.0160922, conv = true
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.6135e-08, relative limit = 0.000102194, conv = true
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.7, relative limit = 0.169772, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16853.3, relative limit = 0.0115918, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.116411, relative limit = 0.000100965, conv = false
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1044.47, relative limit = 0.0154982, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0048847, relative limit = 0.000102025, conv = false
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 35.8941, relative limit = 0.0153342, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000667514, relative limit = 0.000101993, conv = false
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.04465, relative limit = 0.0153141, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.36006e-05, relative limit = 0.000101988, conv = true
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.57744, relative limit = 0.015312, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.53508e-06, relative limit = 0.000101988, conv = true
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0571211, relative limit = 0.0153118, conv = false
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.29515e-06, relative limit = 0.000101988, conv = true
-(0) 16:22:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0102031, relative limit = 0.0153118, conv = true
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.29984e-08, relative limit = 0.000101988, conv = true
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:47 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265, relative limit = 0.233204, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22177, relative limit = 8.20633e-05, conv = false
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23365.9, relative limit = 0.0131086, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0515999, relative limit = 0.000101169, conv = false
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 458.643, relative limit = 0.0147919, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00228458, relative limit = 0.000101655, conv = false
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.4522, relative limit = 0.0148043, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.3059e-05, relative limit = 0.000101641, conv = true
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.59827, relative limit = 0.0148056, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41986e-05, relative limit = 0.000101641, conv = true
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.200931, relative limit = 0.0148051, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31855e-06, relative limit = 0.000101641, conv = true
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00938826, relative limit = 0.0148051, conv = true
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.75791e-07, relative limit = 0.000101641, conv = true
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
-(0) 16:22:48 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28478.8, relative limit = 0.0142547, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.139344, relative limit = 0.000102026, conv = false
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1207.48, relative limit = 0.0148996, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00556548, relative limit = 0.000101143, conv = false
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 44.3611, relative limit = 0.0148095, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000580576, relative limit = 0.000101184, conv = false
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.46464, relative limit = 0.014809, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106998, relative limit = 0.000101189, conv = false
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.814369, relative limit = 0.0148117, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0902e-05, relative limit = 0.000101188, conv = true
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.099174, relative limit = 0.014812, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.79176e-07, relative limit = 0.000101188, conv = true
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00707705, relative limit = 0.014812, conv = true
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08443e-07, relative limit = 0.000101188, conv = true
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.7, relative limit = 0.289552, conv = false
-(0) 16:22:49 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53904, relative limit = 7.77586e-05, conv = false
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28962.6, relative limit = 0.0120986, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0639521, relative limit = 0.000101049, conv = false
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 441.464, relative limit = 0.0146258, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.012013, relative limit = 0.000100741, conv = false
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 98.681, relative limit = 0.0153163, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00044688, relative limit = 0.000100675, conv = false
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32337, relative limit = 0.0153444, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.49468e-05, relative limit = 0.000100674, conv = true
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.257273, relative limit = 0.0153455, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.27263e-06, relative limit = 0.000100674, conv = true
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0600978, relative limit = 0.0153455, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70954e-06, relative limit = 0.000100674, conv = true
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0136432, relative limit = 0.0153455, conv = true
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64231e-07, relative limit = 0.000100674, conv = true
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
-(0) 16:22:50 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27648.8, relative limit = 0.0103064, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103319, relative limit = 0.000100869, conv = false
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 915.599, relative limit = 0.0163205, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0022522, relative limit = 0.00010013, conv = false
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.2175, relative limit = 0.0161873, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00026052, relative limit = 0.000100146, conv = false
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.07887, relative limit = 0.0161741, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11817e-05, relative limit = 0.000100147, conv = true
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.30505, relative limit = 0.0161752, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.30994e-05, relative limit = 0.000100146, conv = true
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102214, relative limit = 0.0161745, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5991e-06, relative limit = 0.000100146, conv = true
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0134354, relative limit = 0.0161744, conv = true
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32901e-07, relative limit = 0.000100146, conv = true
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.8, relative limit = 0.238773, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09876, relative limit = 8.03106e-05, conv = false
-(0) 16:22:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23791.8, relative limit = 0.00832783, conv = false
-(0) 16:22:51 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.139262, relative limit = 0.000100747, conv = false
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1236.78, relative limit = 0.0170458, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00112554, relative limit = 9.96464e-05, conv = false
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.61411, relative limit = 0.0169841, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000282565, relative limit = 9.96538e-05, conv = false
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.05392, relative limit = 0.0169682, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.87406e-05, relative limit = 9.96558e-05, conv = true
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.473259, relative limit = 0.0169655, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.66456e-06, relative limit = 9.96562e-05, conv = true
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0605439, relative limit = 0.0169651, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.52965e-07, relative limit = 9.96563e-05, conv = true
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00129318, relative limit = 0.0169651, conv = true
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26644e-08, relative limit = 9.96563e-05, conv = true
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.7, relative limit = 0.17798, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59418, relative limit = 8.43402e-05, conv = false
-(0) 16:22:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17609.5, relative limit = 0.00587415, conv = false
-(0) 16:22:52 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.1555, relative limit = 0.000100499, conv = false
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1113.99, relative limit = 0.0150222, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0286098, relative limit = 9.94841e-05, conv = false
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 239.221, relative limit = 0.0172641, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00204189, relative limit = 9.92631e-05, conv = false
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15.8035, relative limit = 0.0174136, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000235351, relative limit = 9.92511e-05, conv = false
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95149, relative limit = 0.0174322, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.369e-05, relative limit = 9.92496e-05, conv = true
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122526, relative limit = 0.0174333, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27678e-07, relative limit = 9.92494e-05, conv = true
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00247565, relative limit = 0.0174333, conv = true
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.01561e-08, relative limit = 9.92494e-05, conv = true
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.84, relative limit = 0.101492, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905148, relative limit = 9.04187e-05, conv = false
-(0) 16:22:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9631.34, relative limit = 0.00685574, conv = false
-(0) 16:22:53 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126871, relative limit = 0.000100056, conv = false
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 989.405, relative limit = 0.0160652, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0155815, relative limit = 9.90952e-05, conv = false
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 130.842, relative limit = 0.0173447, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000932428, relative limit = 9.89727e-05, conv = false
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.40208, relative limit = 0.0174171, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000111589, relative limit = 9.89658e-05, conv = false
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00718, relative limit = 0.0174267, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.79494e-06, relative limit = 9.8965e-05, conv = true
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0291285, relative limit = 0.0174264, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.58032e-06, relative limit = 9.8965e-05, conv = true
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0144153, relative limit = 0.0174265, conv = true
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.24503e-08, relative limit = 9.8965e-05, conv = true
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.4, relative limit = 0.0316973, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365139, relative limit = 9.86512e-05, conv = false
-(0) 16:22:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2894.77, relative limit = 0.0132148, conv = false
-(0) 16:22:54 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0452231, relative limit = 9.92103e-05, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 338.725, relative limit = 0.0164984, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00589512, relative limit = 9.88749e-05, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.8269, relative limit = 0.0169103, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000611119, relative limit = 9.88348e-05, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93456, relative limit = 0.0169429, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103162, relative limit = 9.88319e-05, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.927373, relative limit = 0.0169517, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27932e-05, relative limit = 9.8831e-05, conv = true
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110344, relative limit = 0.0169506, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.03882e-06, relative limit = 9.88311e-05, conv = true
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0109412, relative limit = 0.0169506, conv = true
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12079e-07, relative limit = 9.88311e-05, conv = true
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.3, relative limit = 0.0868145, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25801, relative limit = 0.000108871, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11463, relative limit = 0.0307657, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.183738, relative limit = 9.7371e-05, conv = false
-(0) 16:22:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1530.2, relative limit = 0.0169498, conv = false
-(0) 16:22:55 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.014237, relative limit = 9.87632e-05, conv = false
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 145.05, relative limit = 0.0160278, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00265679, relative limit = 9.8881e-05, conv = false
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.8738, relative limit = 0.0161557, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000220897, relative limit = 9.88639e-05, conv = false
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.45017, relative limit = 0.0161646, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.09995e-05, relative limit = 9.88627e-05, conv = true
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.504661, relative limit = 0.0161678, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.58755e-06, relative limit = 9.88623e-05, conv = true
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0638141, relative limit = 0.0161674, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.73947e-07, relative limit = 9.88624e-05, conv = true
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000988149, relative limit = 0.0161674, conv = true
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.67428e-08, relative limit = 9.88624e-05, conv = true
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17945.4, relative limit = 0.16646, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43963, relative limit = 0.000120329, conv = false
-(0) 16:22:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19323.1, relative limit = 0.0293491, conv = false
-(0) 16:22:56 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.198343, relative limit = 9.74155e-05, conv = false
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1735.23, relative limit = 0.0155104, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00409305, relative limit = 9.90279e-05, conv = false
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.6085, relative limit = 0.015364, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.11319e-05, relative limit = 9.90572e-05, conv = true
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.502432, relative limit = 0.0153663, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103292, relative limit = 9.90567e-05, conv = false
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.741035, relative limit = 0.0153638, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5316e-05, relative limit = 9.90574e-05, conv = true
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.119901, relative limit = 0.0153633, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21223e-06, relative limit = 9.90575e-05, conv = true
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00785486, relative limit = 0.0153632, conv = true
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.14097e-07, relative limit = 9.90575e-05, conv = true
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24228.9, relative limit = 0.23241, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56095, relative limit = 0.000131425, conv = false
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25055.2, relative limit = 0.0228472, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.14661, relative limit = 9.81358e-05, conv = false
-(0) 16:22:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1303.4, relative limit = 0.0148248, conv = false
-(0) 16:22:57 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00103787, relative limit = 9.94084e-05, conv = false
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.64782, relative limit = 0.0148618, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000366121, relative limit = 9.94016e-05, conv = false
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.20273, relative limit = 0.0148635, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61423e-05, relative limit = 9.93989e-05, conv = true
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0849012, relative limit = 0.0148633, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.69752e-06, relative limit = 9.93989e-05, conv = true
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0458667, relative limit = 0.0148632, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.36342e-06, relative limit = 9.9399e-05, conv = true
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0119217, relative limit = 0.0148632, conv = true
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1747e-08, relative limit = 9.9399e-05, conv = true
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.5, relative limit = 0.276341, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36998, relative limit = 0.000139835, conv = false
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27256.8, relative limit = 0.0211773, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.104295, relative limit = 0.000100177, conv = false
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 591.186, relative limit = 0.0159742, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0249603, relative limit = 9.99904e-05, conv = false
-(0) 16:22:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 165.645, relative limit = 0.015014, conv = false
-(0) 16:22:58 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00400023, relative limit = 9.98797e-05, conv = false
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 26.8197, relative limit = 0.0148877, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000708038, relative limit = 9.98602e-05, conv = false
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.9146, relative limit = 0.0148816, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.91734e-05, relative limit = 9.98544e-05, conv = true
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.115991, relative limit = 0.0148819, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08103e-05, relative limit = 9.98544e-05, conv = true
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.09545, relative limit = 0.0148816, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.06817e-07, relative limit = 9.98543e-05, conv = true
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00610218, relative limit = 0.0148817, conv = true
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42307e-07, relative limit = 9.98543e-05, conv = true
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.6, relative limit = 0.293276, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64193, relative limit = 0.000143336, conv = false
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27648.9, relative limit = 0.0283322, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.19719, relative limit = 0.000101589, conv = false
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1567.22, relative limit = 0.0152153, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00373635, relative limit = 0.000100356, conv = false
-(0) 16:22:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.333, relative limit = 0.0154122, conv = false
-(0) 16:22:59 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000644774, relative limit = 0.000100384, conv = false
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.58197, relative limit = 0.0153933, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27164e-05, relative limit = 0.000100378, conv = true
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0824421, relative limit = 0.0153936, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.34581e-06, relative limit = 0.000100378, conv = true
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0309993, relative limit = 0.0153938, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50615e-06, relative limit = 0.000100378, conv = true
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0091501, relative limit = 0.0153939, conv = true
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.87646e-07, relative limit = 0.000100378, conv = true
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.8, relative limit = 0.281235, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29132, relative limit = 0.000140981, conv = false
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24721.3, relative limit = 0.0420136, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.35497, relative limit = 0.000103571, conv = false
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3002.89, relative limit = 0.0149607, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.022886, relative limit = 0.000100724, conv = false
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 167.285, relative limit = 0.0159696, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00319296, relative limit = 0.000100893, conv = false
-(0) 16:23:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.1793, relative limit = 0.0160861, conv = false
-(0) 16:23:00 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00125686, relative limit = 0.000100908, conv = false
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.3717, relative limit = 0.0161594, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.8362e-05, relative limit = 0.000100918, conv = true
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.183787, relative limit = 0.0161608, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.7156e-06, relative limit = 0.000100919, conv = true
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.037756, relative limit = 0.0161605, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17774e-07, relative limit = 0.000100919, conv = true
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000993805, relative limit = 0.0161605, conv = true
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.607e-08, relative limit = 0.000100919, conv = true
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355.1, relative limit = 0.241416, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42312, relative limit = 0.000133641, conv = false
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19385.2, relative limit = 0.0540254, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.487246, relative limit = 0.000105295, conv = false
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3428.23, relative limit = 0.020704, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0510835, relative limit = 0.000101822, conv = false
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 499.765, relative limit = 0.0161782, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00963021, relative limit = 0.000101342, conv = false
-(0) 16:23:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 77.0596, relative limit = 0.0168465, conv = false
-(0) 16:23:01 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000410747, relative limit = 0.000101417, conv = false
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37074, relative limit = 0.0168559, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000258513, relative limit = 0.000101418, conv = false
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.8222, relative limit = 0.0168723, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56902e-05, relative limit = 0.00010142, conv = true
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.24375, relative limit = 0.0168745, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9979e-06, relative limit = 0.00010142, conv = true
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.042872, relative limit = 0.0168749, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.87088e-07, relative limit = 0.00010142, conv = true
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00442773, relative limit = 0.0168749, conv = true
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55273e-08, relative limit = 0.00010142, conv = true
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178174, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26838, relative limit = 0.000123387, conv = false
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13413.5, relative limit = 0.0487102, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.39833, relative limit = 0.00010514, conv = false
-(0) 16:23:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2746.52, relative limit = 0.0216262, conv = false
-(0) 16:23:02 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0548412, relative limit = 0.000102271, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 440.913, relative limit = 0.0173811, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00123964, relative limit = 0.000101841, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13.2118, relative limit = 0.0172593, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00039918, relative limit = 0.000101829, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.19854, relative limit = 0.0172894, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14944e-05, relative limit = 0.000101832, conv = true
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.10604, relative limit = 0.0172901, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18241e-06, relative limit = 0.000101832, conv = true
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0138649, relative limit = 0.0172899, conv = true
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.59269e-07, relative limit = 0.000101832, conv = true
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.47, relative limit = 0.0992479, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08132, relative limit = 0.000112386, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6824.89, relative limit = 0.0357724, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.229532, relative limit = 0.000104025, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1765.75, relative limit = 0.0182943, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0133708, relative limit = 0.000102214, conv = false
-(0) 16:23:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 60.507, relative limit = 0.0177723, conv = false
-(0) 16:23:03 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00613668, relative limit = 0.000102166, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.8117, relative limit = 0.017308, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000402456, relative limit = 0.000102118, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49667, relative limit = 0.0172837, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000105693, relative limit = 0.000102115, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.792847, relative limit = 0.017276, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11202e-05, relative limit = 0.000102114, conv = true
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0886042, relative limit = 0.0172751, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.76932e-07, relative limit = 0.000102114, conv = true
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00433956, relative limit = 0.0172751, conv = true
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.7827e-08, relative limit = 0.000102114, conv = true
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.55, relative limit = 0.0315332, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394729, relative limit = 0.000102184, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2968.19, relative limit = 0.0204764, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0499442, relative limit = 0.000102631, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 341.649, relative limit = 0.0173717, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00657775, relative limit = 0.000102297, conv = false
-(0) 16:23:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.9617, relative limit = 0.0169348, conv = false
-(0) 16:23:04 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00127784, relative limit = 0.00010225, conv = false
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.1419, relative limit = 0.0168244, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.48923e-05, relative limit = 0.000102238, conv = true
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.655876, relative limit = 0.01683, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.58093e-05, relative limit = 0.000102239, conv = true
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.121965, relative limit = 0.0168311, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86852e-06, relative limit = 0.000102239, conv = true
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0135145, relative limit = 0.016831, conv = true
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10458e-07, relative limit = 0.000102239, conv = true
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914187, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09217, relative limit = 9.35871e-05, conv = false
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8759.02, relative limit = 0.0097688, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.175506, relative limit = 0.000100706, conv = false
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1477.69, relative limit = 0.0159028, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00383773, relative limit = 0.000102168, conv = false
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25.9793, relative limit = 0.0160521, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000708645, relative limit = 0.000102189, conv = false
-(0) 16:23:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46117, relative limit = 0.0160944, conv = false
-(0) 16:23:05 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.709e-05, relative limit = 0.000102195, conv = true
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.552487, relative limit = 0.0160916, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.90047e-06, relative limit = 0.000102194, conv = true
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.027427, relative limit = 0.0160918, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.70862e-07, relative limit = 0.000102194, conv = true
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00591919, relative limit = 0.0160918, conv = true
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.50128e-07, relative limit = 0.000102194, conv = true
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.7, relative limit = 0.169772, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16812.5, relative limit = 0.011785, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.120912, relative limit = 0.000100932, conv = false
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1112.28, relative limit = 0.015572, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00868592, relative limit = 0.000102049, conv = false
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 63.1058, relative limit = 0.0153345, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00117436, relative limit = 0.000101995, conv = false
-(0) 16:23:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.3638, relative limit = 0.0153074, conv = false
-(0) 16:23:06 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.59545e-05, relative limit = 0.000101987, conv = true
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.967759, relative limit = 0.0153123, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.86262e-05, relative limit = 0.000101988, conv = true
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.230681, relative limit = 0.0153115, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13326e-06, relative limit = 0.000101988, conv = true
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0098631, relative limit = 0.0153115, conv = true
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00504e-07, relative limit = 0.000101988, conv = true
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265, relative limit = 0.233204, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22177, relative limit = 8.20632e-05, conv = false
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23371.8, relative limit = 0.0131062, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0509535, relative limit = 0.000101174, conv = false
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 449.506, relative limit = 0.0147799, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00195568, relative limit = 0.000101652, conv = false
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19.4196, relative limit = 0.0148057, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000390384, relative limit = 0.000101638, conv = false
-(0) 16:23:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55431, relative limit = 0.0148048, conv = false
-(0) 16:23:07 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11102e-05, relative limit = 0.000101641, conv = true
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.216465, relative limit = 0.0148049, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.49644e-06, relative limit = 0.000101641, conv = true
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0429661, relative limit = 0.0148048, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.99237e-07, relative limit = 0.000101641, conv = true
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00406805, relative limit = 0.0148048, conv = true
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11112e-08, relative limit = 0.000101641, conv = true
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28340.7, relative limit = 0.0140473, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.118028, relative limit = 0.000101932, conv = false
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1016.63, relative limit = 0.0148599, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00309635, relative limit = 0.000101163, conv = false
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.894, relative limit = 0.0148228, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000919879, relative limit = 0.00010118, conv = false
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.73104, relative limit = 0.0148125, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.85535e-05, relative limit = 0.000101188, conv = true
-(0) 16:23:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.37435, relative limit = 0.0148118, conv = false
-(0) 16:23:08 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65464e-06, relative limit = 0.000101188, conv = true
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0392767, relative limit = 0.0148119, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11171e-07, relative limit = 0.000101188, conv = true
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00188154, relative limit = 0.0148119, conv = true
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.94563e-08, relative limit = 0.000101188, conv = true
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.6, relative limit = 0.289551, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53903, relative limit = 7.77586e-05, conv = false
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29488.3, relative limit = 0.0118251, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.127802, relative limit = 0.000101532, conv = false
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1126.09, relative limit = 0.0155063, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00412924, relative limit = 0.00010064, conv = false
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 37.7208, relative limit = 0.0153369, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000190419, relative limit = 0.000100675, conv = false
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.972375, relative limit = 0.0153419, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.04855e-05, relative limit = 0.000100674, conv = true
-(0) 16:23:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.726406, relative limit = 0.0153456, conv = false
-(0) 16:23:09 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.71056e-06, relative limit = 0.000100674, conv = true
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0295317, relative limit = 0.0153454, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.14972e-07, relative limit = 0.000100674, conv = true
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00731915, relative limit = 0.0153454, conv = true
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02684e-07, relative limit = 0.000100674, conv = true
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27733.4, relative limit = 0.0101506, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.112516, relative limit = 0.000100951, conv = false
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 915.9, relative limit = 0.0157293, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00702024, relative limit = 0.000100203, conv = false
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 61.6426, relative limit = 0.0161672, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000110645, relative limit = 0.000100147, conv = false
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.917163, relative limit = 0.0161742, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0559e-05, relative limit = 0.000100146, conv = true
-(0) 16:23:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0889366, relative limit = 0.0161747, conv = false
-(0) 16:23:10 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.39963e-06, relative limit = 0.000100146, conv = true
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0157367, relative limit = 0.0161746, conv = true
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4986e-07, relative limit = 0.000100146, conv = true
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.7, relative limit = 0.238773, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09875, relative limit = 8.03106e-05, conv = false
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23913.9, relative limit = 0.00780162, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.154417, relative limit = 0.000100857, conv = false
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1335.75, relative limit = 0.016779, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00238934, relative limit = 9.96725e-05, conv = false
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.20818, relative limit = 0.0168268, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00173867, relative limit = 9.96696e-05, conv = false
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15.186, relative limit = 0.0169626, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41059e-05, relative limit = 9.96564e-05, conv = true
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.300952, relative limit = 0.0169654, conv = false
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47907e-07, relative limit = 9.96562e-05, conv = true
-(0) 16:23:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00548677, relative limit = 0.0169653, conv = true
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.00251e-07, relative limit = 9.96562e-05, conv = true
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:11 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.7, relative limit = 0.177979, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59417, relative limit = 8.43403e-05, conv = false
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17568, relative limit = 0.00632324, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.148557, relative limit = 0.000100466, conv = false
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1301.83, relative limit = 0.0173238, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00137997, relative limit = 9.92576e-05, conv = false
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.5233, relative limit = 0.0174281, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.29574e-05, relative limit = 9.92502e-05, conv = true
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.732333, relative limit = 0.0174326, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22155e-05, relative limit = 9.92495e-05, conv = true
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0924599, relative limit = 0.0174335, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.69548e-06, relative limit = 9.92494e-05, conv = true
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0163035, relative limit = 0.0174336, conv = true
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.15014e-07, relative limit = 9.92494e-05, conv = true
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.77, relative limit = 0.101492, conv = false
-(0) 16:23:12 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905141, relative limit = 9.04188e-05, conv = false
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9624.98, relative limit = 0.0067678, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.127519, relative limit = 0.000100045, conv = false
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 973.323, relative limit = 0.0158772, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177599, relative limit = 9.9112e-05, conv = false
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 142.468, relative limit = 0.0172677, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00182748, relative limit = 9.89799e-05, conv = false
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.0335, relative limit = 0.0174237, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.70899e-05, relative limit = 9.89653e-05, conv = true
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.3336, relative limit = 0.0174269, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34157e-06, relative limit = 9.8965e-05, conv = true
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0204303, relative limit = 0.0174271, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.29797e-06, relative limit = 9.89649e-05, conv = true
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0212253, relative limit = 0.0174269, conv = false
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.95804e-08, relative limit = 9.8965e-05, conv = true
-(0) 16:23:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000712893, relative limit = 0.0174269, conv = true
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82199e-08, relative limit = 9.8965e-05, conv = true
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:13 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.41, relative limit = 0.0316973, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365141, relative limit = 9.86512e-05, conv = false
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2831.42, relative limit = 0.0124143, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0521791, relative limit = 9.92826e-05, conv = false
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 409.239, relative limit = 0.016489, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00535718, relative limit = 9.8878e-05, conv = false
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 32.5214, relative limit = 0.0168091, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00162768, relative limit = 9.88455e-05, conv = false
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.12, relative limit = 0.0169289, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000252931, relative limit = 9.88333e-05, conv = false
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32426, relative limit = 0.016952, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27781e-05, relative limit = 9.8831e-05, conv = true
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110313, relative limit = 0.0169509, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.83737e-07, relative limit = 9.88311e-05, conv = true
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00547146, relative limit = 0.016951, conv = true
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.18028e-07, relative limit = 9.88311e-05, conv = true
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.3, relative limit = 0.0868148, conv = false
-(0) 16:23:14 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25801, relative limit = 0.000108871, conv = false
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11451.9, relative limit = 0.030652, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.182518, relative limit = 9.73814e-05, conv = false
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1501.78, relative limit = 0.0170542, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0164046, relative limit = 9.87507e-05, conv = false
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 108.952, relative limit = 0.0163586, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00368877, relative limit = 9.88373e-05, conv = false
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.972, relative limit = 0.0161765, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000175792, relative limit = 9.88611e-05, conv = false
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.39575, relative limit = 0.0161683, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.19705e-05, relative limit = 9.88622e-05, conv = true
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103053, relative limit = 0.0161678, conv = false
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.66912e-07, relative limit = 9.88623e-05, conv = true
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00375526, relative limit = 0.0161678, conv = true
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:558 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.89429e-08, relative limit = 9.88623e-05, conv = true
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:562 in measureConvergence: [0mAll converged
-(0) 16:23:15 [cplscheme::BaseCouplingScheme]:654 in timeWindowCompleted: [0mTime window completed
-(0) 16:23:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
+Unexpected end of /proc/mounts line `overlay / overlay rw,relatime,lowerdir=/var/lib/docker/overlay2/l/EEEQSQRXSJ7J3DPGNYG4PV2WGQ:/var/lib/docker/overlay2/l/K7M3MWVCA4P4KKYKW7MGVCY3N5:/var/lib/docker/overlay2/l/JOUPYORPWF4TJQC5NK7Y3DUUPO:/var/lib/docker/overlay2/l/WJOR2Q2I7OSBQ3KGKCEWDDLVCD:/var/lib/docker/overlay2/l/PKRYWMTEUHURBUMXUKZZZMUNP2:/var/lib/docker/overlay2/l/BBQG4M7QFFJEYRNSG42NCXGMVY:/var/lib/docker/overlay2/l/KTJAP5NDGS23HT6HPSRUEPS4KD:/var/lib/docker/overlay2/l/DX6BE3UFBR4OBR6CZ4G3CXWCMR:/var/lib/docker/overlay2/l/SP5WTFZRYUKER'
+Unexpected end of /proc/mounts line `WSEQZA5Z467SV:/var/lib/docker/overlay2/l/AGV3IYG5SLJ7IYUVH7OGWIQJTL:/var/lib/docker/overlay2/l/G35TYUGGVV5WFCIKELRGVBLIOA:/var/lib/docker/overlay2/l/4PFCH2B2FRXOOWB7HWRLAYXFIE:/var/lib/docker/overlay2/l/CO7L75I2WTWXRCZDEZGJAAJBXF:/var/lib/docker/overlay2/l/5NMGGQ4OZJUV6OQIK2JMH42LQA:/var/lib/docker/overlay2/l/ZVYOZXGEG6DF4I4A7SO2DIOT5Z:/var/lib/docker/overlay2/l/CAXPKD6OZP3VUJ5NZ4CFWIHSIT:/var/lib/docker/overlay2/l/QXWGBUR4EMFAZK3NZGWEEKHHFS:/var/lib/docker/overlay2/l/4D4UPT5SC6CCA5E4MPJYYJUUPD:/var/lib/do'
+(0) 16:23:37 [impl::SolverInterfaceImpl]:120 in configure: [0mThis is preCICE version 2.0.2
+(0) 16:23:37 [impl::SolverInterfaceImpl]:121 in configure: [0mRevision info: v2.0.2-72-g657f759
+(0) 16:23:37 [impl::SolverInterfaceImpl]:122 in configure: [0mConfiguring preCICE with configuration "./precice-config.xml"
+(0) 16:23:37 [impl::SolverInterfaceImpl]:123 in configure: [0mI am participant "STRUCTURE"
+(0) 16:23:37 [impl::SolverInterfaceImpl]:204 in initialize: [0mSetting up master communication to coupling partner/s
+(0) 16:23:38 [impl::SolverInterfaceImpl]:213 in initialize: [0mMasters are connected
+(0) 16:23:38 [impl::SolverInterfaceImpl]:217 in initialize: [0mSetting up preliminary slaves communication to coupling partner/s
+(0) 16:23:38 [partition::ProvidedPartition]:101 in prepare: [0mPrepare partition for mesh Structure_Nodes
+(0) 16:23:38 [partition::ProvidedPartition]:70 in communicate: [0mGather mesh Structure_Nodes
+(0) 16:23:38 [partition::ProvidedPartition]:87 in communicate: [0mSend global mesh Structure_Nodes
+(0) 16:23:38 [impl::SolverInterfaceImpl]:225 in initialize: [0mSetting up slaves communication to coupling partner/s
+(0) 16:23:38 [impl::SolverInterfaceImpl]:231 in initialize: [0mSlaves are connected
+(0) 16:23:38 [impl::SolverInterfaceImpl]:264 in initialize: [0mit 1 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-initial-data | write-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6165.01, relative limit = 0.0616501, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.743701, relative limit = 0.00010718, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3533.04, relative limit = 0.0267591, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.304414, relative limit = 0.000103132, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3314.03, relative limit = 0.0457024, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.569663, relative limit = 0.000105534, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5215.97, relative limit = 0.079823, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.968817, relative limit = 0.000109217, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4011.76, relative limit = 0.0400411, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.458885, relative limit = 0.000104684, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4662.18, relative limit = 0.00803247, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.093555, relative limit = 9.98625e-05, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 419.679, relative limit = 0.0101152, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.121046, relative limit = 9.96263e-05, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1307.95, relative limit = 0.00401018, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0274171, relative limit = 0.000100854, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 200.627, relative limit = 0.00238801, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00467666, relative limit = 0.000100645, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.4962, relative limit = 0.00222247, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00216145, relative limit = 0.000100617, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 11 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.1818, relative limit = 0.00212782, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000799294, relative limit = 0.000100608, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 12 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.67166, relative limit = 0.00212736, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000649543, relative limit = 0.000100611, conv = false
+(0) 16:23:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 13 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.78319, relative limit = 0.00208865, conv = false
+(0) 16:23:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106639, relative limit = 0.000100608, conv = false
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 14 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.674052, relative limit = 0.00208548, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.10333e-05, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 15 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122316, relative limit = 0.00208472, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.72578e-05, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 16 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0780042, relative limit = 0.00208433, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.43453e-06, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 17 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0561891, relative limit = 0.00208405, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08659e-06, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 18 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149142, relative limit = 0.00208398, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03769e-07, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 19 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00380535, relative limit = 0.00208396, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.52936e-08, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 20 of 100 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000281898, relative limit = 0.00208396, conv = true
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.51638e-09, relative limit = 0.000100607, conv = true
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12146.8, relative limit = 0.122861, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.57201, relative limit = 0.000114844, conv = false
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12108.6, relative limit = 0.0128916, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.166286, relative limit = 0.000101103, conv = false
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1409.58, relative limit = 0.00263847, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0519035, relative limit = 0.000100403, conv = false
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 271.453, relative limit = 0.00369663, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0200367, relative limit = 0.000100652, conv = false
+(0) 16:23:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 172.855, relative limit = 0.00505874, conv = false
+(0) 16:23:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000477047, relative limit = 0.000100811, conv = false
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.53876, relative limit = 0.00502772, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.26161e-05, relative limit = 0.000100809, conv = true
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.494316, relative limit = 0.00502542, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.17997e-05, relative limit = 0.00010081, conv = true
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0815479, relative limit = 0.00502599, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43735e-06, relative limit = 0.00010081, conv = true
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177596, relative limit = 0.00502608, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.38037e-07, relative limit = 0.00010081, conv = true
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 2 | t 0.01 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00394795, relative limit = 0.00502612, conv = true
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41649e-08, relative limit = 0.00010081, conv = true
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16550.5, relative limit = 0.169287, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26335, relative limit = 0.000121494, conv = false
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17272.7, relative limit = 0.00484477, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.124546, relative limit = 0.000100117, conv = false
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 752.682, relative limit = 0.00573348, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0365783, relative limit = 0.0001008, conv = false
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 265.181, relative limit = 0.00792483, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00528231, relative limit = 0.000101045, conv = false
+(0) 16:23:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.6007, relative limit = 0.00833741, conv = false
+(0) 16:23:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000343969, relative limit = 0.00010109, conv = false
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49309, relative limit = 0.0083144, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.33775e-05, relative limit = 0.000101088, conv = true
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.34328, relative limit = 0.00831125, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66769e-06, relative limit = 0.000101088, conv = true
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0160645, relative limit = 0.00831112, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.37897e-07, relative limit = 0.000101088, conv = true
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 3 | t 0.02 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00640699, relative limit = 0.00831106, conv = true
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.05922e-08, relative limit = 0.000101088, conv = true
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18774.1, relative limit = 0.194531, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.64444, relative limit = 0.000125488, conv = false
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18379.3, relative limit = 0.0130607, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0311455, relative limit = 0.000101426, conv = false
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 250.096, relative limit = 0.0106402, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0146111, relative limit = 0.000101291, conv = false
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 104.613, relative limit = 0.0113552, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00210778, relative limit = 0.000101396, conv = false
+(0) 16:23:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.5665, relative limit = 0.0115202, conv = false
+(0) 16:23:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32346e-05, relative limit = 0.000101413, conv = true
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180996, relative limit = 0.0115198, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.85222e-05, relative limit = 0.000101413, conv = true
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126225, relative limit = 0.0115209, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63625e-06, relative limit = 0.000101413, conv = true
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.029986, relative limit = 0.0115212, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14348e-08, relative limit = 0.000101413, conv = true
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 4 | t 0.03 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000309636, relative limit = 0.0115212, conv = true
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.07888e-09, relative limit = 0.000101413, conv = true
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18488.6, relative limit = 0.194886, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.59978, relative limit = 0.000125652, conv = false
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17729.1, relative limit = 0.019528, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.068649, relative limit = 0.00010216, conv = false
+(0) 16:23:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 598.762, relative limit = 0.0135888, conv = false
+(0) 16:23:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00893535, relative limit = 0.000101673, conv = false
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 75.9334, relative limit = 0.0143151, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0001122, relative limit = 0.00010175, conv = false
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.899986, relative limit = 0.0143107, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.18755e-06, relative limit = 0.00010175, conv = true
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0587134, relative limit = 0.0143106, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.07823e-06, relative limit = 0.00010175, conv = true
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0222289, relative limit = 0.0143104, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.27414e-07, relative limit = 0.00010175, conv = true
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 5 | t 0.04 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00330534, relative limit = 0.0143104, conv = true
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.30564e-08, relative limit = 0.00010175, conv = true
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15669.5, relative limit = 0.169663, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.13334, relative limit = 0.000121889, conv = false
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 14423.8, relative limit = 0.0271723, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.134743, relative limit = 0.000103043, conv = false
+(0) 16:23:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 939.669, relative limit = 0.0178336, conv = false
+(0) 16:23:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0172954, relative limit = 0.000102191, conv = false
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 138.785, relative limit = 0.0164501, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00041797, relative limit = 0.000102062, conv = false
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11993, relative limit = 0.016423, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68655e-05, relative limit = 0.000102059, conv = true
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.532023, relative limit = 0.016419, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.54402e-05, relative limit = 0.000102058, conv = true
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110826, relative limit = 0.0164201, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87027e-06, relative limit = 0.000102058, conv = true
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 6 | t 0.05 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0154785, relative limit = 0.0164202, conv = true
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.95439e-08, relative limit = 0.000102058, conv = true
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10628.8, relative limit = 0.121495, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.36818, relative limit = 0.000115201, conv = false
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9308.46, relative limit = 0.0299392, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.151981, relative limit = 0.000103501, conv = false
+(0) 16:23:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 911.606, relative limit = 0.020904, conv = false
+(0) 16:23:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0394008, relative limit = 0.000102613, conv = false
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 319.679, relative limit = 0.0177452, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000551635, relative limit = 0.000102305, conv = false
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46456, relative limit = 0.017702, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74288e-05, relative limit = 0.0001023, conv = true
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.115237, relative limit = 0.0177014, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12381e-06, relative limit = 0.0001023, conv = true
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 7 | t 0.06 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00563551, relative limit = 0.0177014, conv = true
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.72169e-07, relative limit = 0.0001023, conv = true
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4228.95, relative limit = 0.0573698, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.510009, relative limit = 0.000107099, conv = false
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3483.29, relative limit = 0.0252518, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0878921, relative limit = 0.000103179, conv = false
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 671.92, relative limit = 0.0186843, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0067114, relative limit = 0.0001025, conv = false
+(0) 16:23:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 49.6178, relative limit = 0.0181919, conv = false
+(0) 16:23:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000756023, relative limit = 0.000102448, conv = false
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.2874, relative limit = 0.0181301, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.56893e-06, relative limit = 0.000102442, conv = true
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0715704, relative limit = 0.0181295, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.12984e-06, relative limit = 0.000102442, conv = true
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0341514, relative limit = 0.0181299, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.75484e-08, relative limit = 0.000102442, conv = true
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 8 | t 0.07 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00026569, relative limit = 0.0181299, conv = true
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.76946e-09, relative limit = 0.000102442, conv = true
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4919.86, relative limit = 0.0358635, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.539987, relative limit = 9.89571e-05, conv = false
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4393.14, relative limit = 0.016888, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0391464, relative limit = 0.000102316, conv = false
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 273.556, relative limit = 0.0178207, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00378493, relative limit = 0.000102456, conv = false
+(0) 16:23:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.7737, relative limit = 0.0178254, conv = false
+(0) 16:23:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000397235, relative limit = 0.000102459, conv = false
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.37756, relative limit = 0.0178173, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.97154e-05, relative limit = 0.000102458, conv = true
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.557688, relative limit = 0.0178147, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.21908e-06, relative limit = 0.000102457, conv = true
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0436967, relative limit = 0.0178145, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.63905e-06, relative limit = 0.000102457, conv = true
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 9 | t 0.08 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0122344, relative limit = 0.0178144, conv = true
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12355e-08, relative limit = 0.000102457, conv = true
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12461.7, relative limit = 0.109261, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2711, relative limit = 9.16979e-05, conv = false
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11052.9, relative limit = 0.0112798, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.129551, relative limit = 0.000101258, conv = false
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1187.82, relative limit = 0.0174964, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0099633, relative limit = 0.000102405, conv = false
+(0) 16:23:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 68.0961, relative limit = 0.0170793, conv = false
+(0) 16:23:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00174317, relative limit = 0.000102346, conv = false
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13.0016, relative limit = 0.0170016, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000177191, relative limit = 0.000102335, conv = false
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.46767, relative limit = 0.016994, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.03011e-06, relative limit = 0.000102334, conv = true
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0366602, relative limit = 0.0169943, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56535e-06, relative limit = 0.000102334, conv = true
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 10 | t 0.09 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0124476, relative limit = 0.0169943, conv = true
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.66638e-08, relative limit = 0.000102334, conv = true
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19517.8, relative limit = 0.181923, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86823, relative limit = 8.58043e-05, conv = false
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18469, relative limit = 0.0126255, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.076649, relative limit = 0.000101396, conv = false
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 684.014, relative limit = 0.0160539, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00426986, relative limit = 0.000102096, conv = false
+(0) 16:23:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 41.7129, relative limit = 0.0159824, conv = false
+(0) 16:23:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000955157, relative limit = 0.000102066, conv = false
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.71699, relative limit = 0.0160212, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.37506e-05, relative limit = 0.000102074, conv = true
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.476149, relative limit = 0.0160192, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76899e-05, relative limit = 0.000102074, conv = true
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.157122, relative limit = 0.0160184, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47267e-07, relative limit = 0.000102074, conv = true
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 11 | t 0.1 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00823312, relative limit = 0.0160184, conv = true
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.48761e-07, relative limit = 0.000102074, conv = true
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25058.8, relative limit = 0.240768, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.28381, relative limit = 8.14644e-05, conv = false
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24538.6, relative limit = 0.0128302, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0387785, relative limit = 0.000101551, conv = false
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 223.021, relative limit = 0.0147649, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00793704, relative limit = 0.000101662, conv = false
+(0) 16:23:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 57.1066, relative limit = 0.0152679, conv = false
+(0) 16:23:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000586091, relative limit = 0.000101687, conv = false
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.50616, relative limit = 0.0152826, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.96177e-05, relative limit = 0.000101693, conv = true
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.431794, relative limit = 0.0152821, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.28199e-06, relative limit = 0.000101692, conv = true
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0201834, relative limit = 0.0152822, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18027e-06, relative limit = 0.000101692, conv = true
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 12 | t 0.11 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00798031, relative limit = 0.0152822, conv = true
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.42578e-07, relative limit = 0.000101692, conv = true
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28444, relative limit = 0.278928, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.51294, relative limit = 7.87206e-05, conv = false
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28059.6, relative limit = 0.0124772, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0437367, relative limit = 0.00010125, conv = false
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 271.881, relative limit = 0.0147035, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00847004, relative limit = 0.000101257, conv = false
+(0) 16:23:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 66.1486, relative limit = 0.0150768, conv = false
+(0) 16:23:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000405966, relative limit = 0.000101221, conv = false
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55144, relative limit = 0.015089, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.40797e-05, relative limit = 0.000101218, conv = true
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.247157, relative limit = 0.0150873, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.85245e-06, relative limit = 0.000101218, conv = true
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0533453, relative limit = 0.0150875, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.99102e-07, relative limit = 0.000101218, conv = true
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 13 | t 0.12 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00617198, relative limit = 0.0150875, conv = true
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.04268e-07, relative limit = 0.000101218, conv = true
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29288, relative limit = 0.292121, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.55886, relative limit = 7.75756e-05, conv = false
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29280.5, relative limit = 0.011798, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0736661, relative limit = 0.000101104, conv = false
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 650.031, relative limit = 0.0156987, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00352451, relative limit = 0.000100673, conv = false
+(0) 16:23:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.3141, relative limit = 0.0154824, conv = false
+(0) 16:23:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.25075e-05, relative limit = 0.000100691, conv = true
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.698478, relative limit = 0.0154789, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53411e-05, relative limit = 0.000100692, conv = true
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.228566, relative limit = 0.0154798, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.97292e-07, relative limit = 0.000100692, conv = true
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 14 | t 0.13 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00426461, relative limit = 0.0154798, conv = true
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63943e-07, relative limit = 0.000100692, conv = true
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27470.3, relative limit = 0.278685, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.4239, relative limit = 7.80568e-05, conv = false
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27893.2, relative limit = 0.0101163, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.114578, relative limit = 0.000100965, conv = false
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 912.418, relative limit = 0.0155535, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00929234, relative limit = 0.000100217, conv = false
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 71.3355, relative limit = 0.0161509, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00106037, relative limit = 0.000100165, conv = false
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.00571, relative limit = 0.016225, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.89612e-05, relative limit = 0.000100158, conv = true
+(0) 16:23:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.283219, relative limit = 0.0162272, conv = false
+(0) 16:23:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.74146e-06, relative limit = 0.000100158, conv = true
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0277388, relative limit = 0.016227, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.94529e-07, relative limit = 0.000100158, conv = true
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 15 | t 0.14 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00463592, relative limit = 0.016227, conv = true
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00563e-07, relative limit = 0.000100158, conv = true
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23136.8, relative limit = 0.239609, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10583, relative limit = 8.02491e-05, conv = false
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23769.6, relative limit = 0.00837646, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.128148, relative limit = 0.000100631, conv = false
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1148.87, relative limit = 0.0171982, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00303331, relative limit = 9.96373e-05, conv = false
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28.053, relative limit = 0.0169696, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106124, relative limit = 9.96645e-05, conv = false
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.840465, relative limit = 0.0169752, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10352e-05, relative limit = 9.96637e-05, conv = true
+(0) 16:23:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.106513, relative limit = 0.016976, conv = false
+(0) 16:23:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31913e-06, relative limit = 9.96636e-05, conv = true
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 16 | t 0.15 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00643433, relative limit = 0.016976, conv = true
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.32484e-07, relative limit = 9.96636e-05, conv = true
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16694.7, relative limit = 0.178483, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5989, relative limit = 8.43003e-05, conv = false
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17768.3, relative limit = 0.00570889, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.16666, relative limit = 0.000100617, conv = false
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1362.82, relative limit = 0.0164068, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0120516, relative limit = 9.93533e-05, conv = false
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 105.045, relative limit = 0.0173957, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000349908, relative limit = 9.92575e-05, conv = false
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.76866, relative limit = 0.0174209, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.28626e-05, relative limit = 9.9255e-05, conv = true
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.354395, relative limit = 0.0174242, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.70704e-06, relative limit = 9.92547e-05, conv = true
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0221127, relative limit = 0.0174243, conv = false
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2916e-06, relative limit = 9.92546e-05, conv = true
+(0) 16:23:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 17 | t 0.16 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00996949, relative limit = 0.0174244, conv = true
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95854e-07, relative limit = 9.92546e-05, conv = true
+(0) 16:23:54 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8879.38, relative limit = 0.101814, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.908577, relative limit = 9.03896e-05, conv = false
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9651.12, relative limit = 0.00682351, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126501, relative limit = 0.000100038, conv = false
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 955.423, relative limit = 0.0157814, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0186, relative limit = 9.91272e-05, conv = false
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 164.449, relative limit = 0.0173854, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000291064, relative limit = 9.8971e-05, conv = false
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.38003, relative limit = 0.0174068, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.5614e-05, relative limit = 9.89691e-05, conv = true
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.234627, relative limit = 0.0174089, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.10639e-06, relative limit = 9.89689e-05, conv = true
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 18 | t 0.17 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0159889, relative limit = 0.0174088, conv = true
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41775e-07, relative limit = 9.89689e-05, conv = true
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3288.25, relative limit = 0.0317863, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.364858, relative limit = 9.86271e-05, conv = false
+(0) 16:23:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2802.88, relative limit = 0.00990207, conv = false
+(0) 16:23:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0825447, relative limit = 9.95691e-05, conv = false
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 699.824, relative limit = 0.0165404, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00513699, relative limit = 9.88723e-05, conv = false
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 35.8604, relative limit = 0.0168674, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000778216, relative limit = 9.88404e-05, conv = false
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.16279, relative limit = 0.0169265, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.04488e-05, relative limit = 9.88346e-05, conv = true
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.3688, relative limit = 0.01693, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.77091e-06, relative limit = 9.88343e-05, conv = true
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0471803, relative limit = 0.0169296, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.60675e-07, relative limit = 9.88343e-05, conv = true
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 19 | t 0.18 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00631037, relative limit = 0.0169296, conv = true
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.76762e-08, relative limit = 9.88343e-05, conv = true
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10116.8, relative limit = 0.0866609, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25566, relative limit = 0.000108849, conv = false
+(0) 16:23:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11449.5, relative limit = 0.0308185, conv = false
+(0) 16:23:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.184156, relative limit = 9.7365e-05, conv = false
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1517.26, relative limit = 0.0170489, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0163557, relative limit = 9.87522e-05, conv = false
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 144.709, relative limit = 0.0161261, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000524166, relative limit = 9.8868e-05, conv = false
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.90634, relative limit = 0.0161511, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.23873e-05, relative limit = 9.88644e-05, conv = true
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.462858, relative limit = 0.0161479, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98414e-05, relative limit = 9.88648e-05, conv = true
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.216819, relative limit = 0.0161465, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.28391e-06, relative limit = 9.8865e-05, conv = true
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0495761, relative limit = 0.0161468, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.39828e-07, relative limit = 9.8865e-05, conv = true
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 20 | t 0.19 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00451776, relative limit = 0.0161467, conv = true
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.32372e-08, relative limit = 9.8865e-05, conv = true
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17930.7, relative limit = 0.166332, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43735, relative limit = 0.000120309, conv = false
+(0) 16:23:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19353, relative limit = 0.0296832, conv = false
+(0) 16:23:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.203463, relative limit = 9.73821e-05, conv = false
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1847.93, relative limit = 0.0152352, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00414472, relative limit = 9.90879e-05, conv = false
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.706, relative limit = 0.0153392, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106168, relative limit = 9.90601e-05, conv = false
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.857157, relative limit = 0.0153446, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.03517e-05, relative limit = 9.90598e-05, conv = true
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.265477, relative limit = 0.0153459, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.05987e-05, relative limit = 9.90596e-05, conv = true
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0893849, relative limit = 0.0153455, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11862e-07, relative limit = 9.90596e-05, conv = true
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 21 | t 0.2 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00148032, relative limit = 0.0153455, conv = true
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.89432e-08, relative limit = 9.90597e-05, conv = true
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24217, relative limit = 0.232307, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55885, relative limit = 0.000131407, conv = false
+(0) 16:23:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25020.2, relative limit = 0.0226865, conv = false
+(0) 16:23:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.143967, relative limit = 9.81582e-05, conv = false
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1329.54, relative limit = 0.0148254, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00728238, relative limit = 9.94538e-05, conv = false
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 55.6744, relative limit = 0.014841, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00063336, relative limit = 9.94059e-05, conv = false
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.21507, relative limit = 0.0148501, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49048e-05, relative limit = 9.94011e-05, conv = true
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.23491, relative limit = 0.0148504, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7205e-06, relative limit = 9.94008e-05, conv = true
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0216451, relative limit = 0.0148503, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.96605e-07, relative limit = 9.94009e-05, conv = true
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 22 | t 0.21 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00136171, relative limit = 0.0148503, conv = true
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.78044e-08, relative limit = 9.94009e-05, conv = true
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28203.8, relative limit = 0.276259, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36813, relative limit = 0.000139819, conv = false
+(0) 16:23:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27326.9, relative limit = 0.0212985, conv = false
+(0) 16:23:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.104473, relative limit = 0.000100097, conv = false
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 720.167, relative limit = 0.0150154, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00697879, relative limit = 9.99092e-05, conv = false
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 62.605, relative limit = 0.0148484, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000604269, relative limit = 9.98533e-05, conv = false
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.10088, relative limit = 0.0148719, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000121055, relative limit = 9.9857e-05, conv = false
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.06047, relative limit = 0.0148747, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.74725e-06, relative limit = 9.98559e-05, conv = true
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0584573, relative limit = 0.0148744, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09093e-06, relative limit = 9.98559e-05, conv = true
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0148838, relative limit = 0.0148744, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.24865e-07, relative limit = 9.98559e-05, conv = true
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 23 | t 0.22 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00341797, relative limit = 0.0148744, conv = true
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.60429e-08, relative limit = 9.98559e-05, conv = true
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29435.8, relative limit = 0.29321, conv = false
+(0) 16:24:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64037, relative limit = 0.000143322, conv = false
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27773.3, relative limit = 0.0271975, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180075, relative limit = 0.000101454, conv = false
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1439.95, relative limit = 0.0151582, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00477429, relative limit = 0.000100349, conv = false
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 49.8318, relative limit = 0.0154193, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00154615, relative limit = 0.000100394, conv = false
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.5011, relative limit = 0.0153993, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000256003, relative limit = 0.000100382, conv = false
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.74989, relative limit = 0.0153936, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27764e-05, relative limit = 0.00010038, conv = true
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.414015, relative limit = 0.0153917, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.76915e-06, relative limit = 0.00010038, conv = true
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0250302, relative limit = 0.0153916, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.56695e-07, relative limit = 0.00010038, conv = true
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 24 | t 0.23 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00729339, relative limit = 0.0153916, conv = true
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50811e-08, relative limit = 0.00010038, conv = true
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27761.2, relative limit = 0.28118, conv = false
+(0) 16:24:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29007, relative limit = 0.000140971, conv = false
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25081.8, relative limit = 0.0389096, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.31242, relative limit = 0.000103155, conv = false
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2615.13, relative limit = 0.0150998, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0180292, relative limit = 0.000100777, conv = false
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 143.426, relative limit = 0.0161044, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000858246, relative limit = 0.000100915, conv = false
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.15573, relative limit = 0.0161796, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000301271, relative limit = 0.000100922, conv = false
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.36428, relative limit = 0.016163, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.00879e-05, relative limit = 0.00010092, conv = true
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122006, relative limit = 0.0161622, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.14694e-06, relative limit = 0.00010092, conv = true
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0522091, relative limit = 0.0161619, conv = false
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.5768e-08, relative limit = 0.00010092, conv = true
+(0) 16:24:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 25 | t 0.24 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000945208, relative limit = 0.0161619, conv = true
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.09621e-08, relative limit = 0.00010092, conv = true
+(0) 16:24:02 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23349.4, relative limit = 0.24137, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42214, relative limit = 0.000133633, conv = false
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20060.9, relative limit = 0.0469683, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.393162, relative limit = 0.000104504, conv = false
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2433.34, relative limit = 0.0233029, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0847635, relative limit = 0.000102075, conv = false
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 569.399, relative limit = 0.0179873, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149424, relative limit = 0.000101536, conv = false
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 116.94, relative limit = 0.0169301, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000717287, relative limit = 0.000101426, conv = false
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.38391, relative limit = 0.0168726, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.21889e-05, relative limit = 0.000101421, conv = true
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.641228, relative limit = 0.0168782, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.54118e-06, relative limit = 0.000101421, conv = true
+(0) 16:24:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0417486, relative limit = 0.0168785, conv = false
+(0) 16:24:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.1405e-07, relative limit = 0.000101421, conv = true
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 26 | t 0.25 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00470566, relative limit = 0.0168785, conv = true
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02639e-07, relative limit = 0.000101421, conv = true
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16688.5, relative limit = 0.178133, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26762, relative limit = 0.000123381, conv = false
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13667.5, relative limit = 0.0462535, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.367032, relative limit = 0.000104839, conv = false
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2929.89, relative limit = 0.0174661, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00535577, relative limit = 0.000101836, conv = false
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 50.4127, relative limit = 0.0170978, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00249983, relative limit = 0.000101813, conv = false
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.202, relative limit = 0.0172613, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000427394, relative limit = 0.00010183, conv = false
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06288, relative limit = 0.0172904, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.66538e-05, relative limit = 0.000101833, conv = true
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.477938, relative limit = 0.017295, conv = false
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12195e-06, relative limit = 0.000101833, conv = true
+(0) 16:24:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 27 | t 0.26 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0051919, relative limit = 0.017295, conv = true
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.20163e-07, relative limit = 0.000101833, conv = true
+(0) 16:24:04 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8647.16, relative limit = 0.0992111, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08075, relative limit = 0.000112382, conv = false
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7106.41, relative limit = 0.0313299, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.17211, relative limit = 0.000103615, conv = false
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1172.53, relative limit = 0.0197009, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0297327, relative limit = 0.000102367, conv = false
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 258.332, relative limit = 0.0171707, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00143299, relative limit = 0.000102103, conv = false
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.4434, relative limit = 0.0173499, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000849029, relative limit = 0.000102122, conv = false
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.02245, relative limit = 0.0172814, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.271e-06, relative limit = 0.000102115, conv = true
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0622542, relative limit = 0.0172808, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.94334e-06, relative limit = 0.000102115, conv = true
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 28 | t 0.27 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0132384, relative limit = 0.0172807, conv = true
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.95168e-07, relative limit = 0.000102115, conv = true
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3463.03, relative limit = 0.0315301, conv = false
+(0) 16:24:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394871, relative limit = 0.00010218, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3046.49, relative limit = 0.0206295, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0475147, relative limit = 0.000102654, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 398.943, relative limit = 0.0166595, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0052836, relative limit = 0.000102219, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 40.8979, relative limit = 0.0168322, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00014562, relative limit = 0.000102239, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.66457, relative limit = 0.0168458, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000110056, relative limit = 0.00010224, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.758232, relative limit = 0.0168383, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89627e-05, relative limit = 0.00010224, conv = true
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.154978, relative limit = 0.0168368, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.95231e-07, relative limit = 0.000102239, conv = true
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 29 | t 0.28 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00257994, relative limit = 0.0168368, conv = true
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32078e-07, relative limit = 0.000102239, conv = true
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10575.1, relative limit = 0.0914529, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09256, relative limit = 9.35841e-05, conv = false
+(0) 16:24:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8766.64, relative limit = 0.00976128, conv = false
+(0) 16:24:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.175064, relative limit = 0.00010071, conv = false
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1468.17, relative limit = 0.0158796, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00462596, relative limit = 0.000102164, conv = false
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 45.3605, relative limit = 0.0161379, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00087673, relative limit = 0.000102201, conv = false
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.10466, relative limit = 0.0161026, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000138157, relative limit = 0.000102196, conv = false
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.885029, relative limit = 0.0160986, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.8599e-05, relative limit = 0.000102195, conv = true
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.194449, relative limit = 0.0160976, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.58579e-06, relative limit = 0.000102195, conv = true
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0409741, relative limit = 0.0160974, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59182e-07, relative limit = 0.000102195, conv = true
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 30 | t 0.29 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00379089, relative limit = 0.0160975, conv = true
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.52803e-09, relative limit = 0.000102195, conv = true
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18246.6, relative limit = 0.169806, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.76027, relative limit = 8.6876e-05, conv = false
+(0) 16:24:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16803.5, relative limit = 0.01184, conv = false
+(0) 16:24:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122281, relative limit = 0.000100921, conv = false
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1158.76, relative limit = 0.0157655, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0126501, relative limit = 0.000102082, conv = false
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 106.316, relative limit = 0.0153149, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.93387e-05, relative limit = 0.000101989, conv = true
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18761, relative limit = 0.0153147, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.39006e-05, relative limit = 0.000101988, conv = true
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.930261, relative limit = 0.0153179, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.75197e-05, relative limit = 0.000101989, conv = true
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.340647, relative limit = 0.0153165, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.69175e-06, relative limit = 0.000101989, conv = true
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0204915, relative limit = 0.0153166, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.56545e-07, relative limit = 0.000101989, conv = true
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 31 | t 0.3 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0021351, relative limit = 0.0153166, conv = true
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13095e-08, relative limit = 0.000101989, conv = true
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24268.6, relative limit = 0.233235, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22205, relative limit = 8.20612e-05, conv = false
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23386.7, relative limit = 0.0130927, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0498023, relative limit = 0.000101186, conv = false
+(0) 16:24:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 411.235, relative limit = 0.0147332, conv = false
+(0) 16:24:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00190331, relative limit = 0.000101625, conv = false
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 14.844, relative limit = 0.0148074, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000150761, relative limit = 0.00010164, conv = false
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.12301, relative limit = 0.014809, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75226e-05, relative limit = 0.000101641, conv = true
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.13362, relative limit = 0.014809, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86004e-06, relative limit = 0.000101641, conv = true
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 32 | t 0.31 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0120248, relative limit = 0.014809, conv = true
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14046e-07, relative limit = 0.000101641, conv = true
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27976, relative limit = 0.274475, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47818, relative limit = 7.90494e-05, conv = false
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28483.9, relative limit = 0.0146593, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.135251, relative limit = 0.000102055, conv = false
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1164.73, relative limit = 0.0148412, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00366483, relative limit = 0.000101158, conv = false
+(0) 16:24:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 33.7309, relative limit = 0.0148164, conv = false
+(0) 16:24:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000274616, relative limit = 0.000101191, conv = false
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.01601, relative limit = 0.0148144, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.13478e-05, relative limit = 0.000101189, conv = true
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.431834, relative limit = 0.0148149, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.27852e-06, relative limit = 0.000101189, conv = true
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0375114, relative limit = 0.0148149, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42821e-06, relative limit = 0.000101189, conv = true
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 33 | t 0.32 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00902057, relative limit = 0.0148148, conv = true
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.63883e-07, relative limit = 0.000101189, conv = true
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29019.5, relative limit = 0.289577, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53924, relative limit = 7.77571e-05, conv = false
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29767.9, relative limit = 0.0128617, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.16107, relative limit = 0.000101795, conv = false
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1276.56, relative limit = 0.0147658, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0112893, relative limit = 0.000100753, conv = false
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 100.1, relative limit = 0.0153595, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000235612, relative limit = 0.000100672, conv = false
+(0) 16:24:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82035, relative limit = 0.0153485, conv = false
+(0) 16:24:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.88042e-05, relative limit = 0.000100674, conv = true
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.372656, relative limit = 0.0153464, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.56443e-05, relative limit = 0.000100674, conv = true
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.108835, relative limit = 0.015347, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.15189e-06, relative limit = 0.000100674, conv = true
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0261171, relative limit = 0.0153471, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.67929e-07, relative limit = 0.000100674, conv = true
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 34 | t 0.33 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000935233, relative limit = 0.0153471, conv = true
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.00308e-08, relative limit = 0.000100674, conv = true
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27317.9, relative limit = 0.277251, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41255, relative limit = 7.8159e-05, conv = false
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28029.6, relative limit = 0.0102083, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.146524, relative limit = 0.000101243, conv = false
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1139.86, relative limit = 0.0151569, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0156603, relative limit = 0.000100266, conv = false
+(0) 16:24:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 132.189, relative limit = 0.01613, conv = false
+(0) 16:24:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00067971, relative limit = 0.000100151, conv = false
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.27593, relative limit = 0.0161706, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.60053e-05, relative limit = 0.000100147, conv = true
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.758213, relative limit = 0.0161757, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31422e-05, relative limit = 0.000100147, conv = true
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.105207, relative limit = 0.0161752, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.49461e-06, relative limit = 0.000100147, conv = true
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 35 | t 0.34 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0134152, relative limit = 0.0161751, conv = true
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.22907e-08, relative limit = 0.000100147, conv = true
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23048.8, relative limit = 0.238791, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09892, relative limit = 8.03094e-05, conv = false
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24109.3, relative limit = 0.00826114, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.1744, relative limit = 0.000101066, conv = false
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1542.75, relative limit = 0.0170667, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00150345, relative limit = 9.96518e-05, conv = false
+(0) 16:24:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.5567, relative limit = 0.0169855, conv = false
+(0) 16:24:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000276863, relative limit = 9.96545e-05, conv = false
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.1613, relative limit = 0.0169673, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09894e-05, relative limit = 9.96563e-05, conv = true
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.248542, relative limit = 0.0169652, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.24618e-06, relative limit = 9.96565e-05, conv = true
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0249834, relative limit = 0.016965, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.83888e-07, relative limit = 9.96565e-05, conv = true
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 36 | t 0.35 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00437367, relative limit = 0.016965, conv = true
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.39243e-08, relative limit = 9.96565e-05, conv = true
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16641.3, relative limit = 0.177994, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59432, relative limit = 8.43392e-05, conv = false
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17764.1, relative limit = 0.00544489, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.17307, relative limit = 0.000100657, conv = false
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1529, relative limit = 0.0174818, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00128688, relative limit = 9.92483e-05, conv = false
+(0) 16:24:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.41642, relative limit = 0.0174383, conv = false
+(0) 16:24:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000273781, relative limit = 9.92499e-05, conv = false
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09531, relative limit = 0.0174319, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.09311e-05, relative limit = 9.92498e-05, conv = true
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.256078, relative limit = 0.0174323, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.03299e-06, relative limit = 9.92497e-05, conv = true
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0402457, relative limit = 0.0174326, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.44024e-07, relative limit = 9.92497e-05, conv = true
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 37 | t 0.36 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00551464, relative limit = 0.0174327, conv = true
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.58023e-08, relative limit = 9.92497e-05, conv = true
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8845.09, relative limit = 0.101503, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.90527, relative limit = 9.04178e-05, conv = false
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9559.68, relative limit = 0.00737698, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.119541, relative limit = 9.9975e-05, conv = false
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 992.65, relative limit = 0.016767, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00762473, relative limit = 9.90298e-05, conv = false
+(0) 16:24:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 67.2022, relative limit = 0.0174128, conv = false
+(0) 16:24:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000271969, relative limit = 9.89667e-05, conv = false
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.15981, relative limit = 0.0174247, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.18933e-05, relative limit = 9.89653e-05, conv = true
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.263391, relative limit = 0.0174257, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.45306e-06, relative limit = 9.89652e-05, conv = true
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0259615, relative limit = 0.0174256, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.49887e-07, relative limit = 9.89652e-05, conv = true
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 38 | t 0.37 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00468133, relative limit = 0.0174256, conv = true
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35957e-07, relative limit = 9.89652e-05, conv = true
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.36, relative limit = 0.0317005, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365129, relative limit = 9.86503e-05, conv = false
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2841.18, relative limit = 0.0112215, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0659538, relative limit = 9.94269e-05, conv = false
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 529.559, relative limit = 0.0163906, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00658737, relative limit = 9.8888e-05, conv = false
+(0) 16:24:15 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 48.2465, relative limit = 0.016863, conv = false
+(0) 16:24:15 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00101058, relative limit = 9.88399e-05, conv = false
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.91087, relative limit = 0.0169412, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.72831e-05, relative limit = 9.88321e-05, conv = true
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.7814, relative limit = 0.0169489, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.70424e-06, relative limit = 9.88314e-05, conv = true
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0628729, relative limit = 0.0169494, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.34137e-07, relative limit = 9.88313e-05, conv = true
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 39 | t 0.38 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00312503, relative limit = 0.0169495, conv = true
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03958e-08, relative limit = 9.88313e-05, conv = true
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10133.6, relative limit = 0.0868091, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25792, relative limit = 0.00010887, conv = false
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11442.5, relative limit = 0.030554, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.181592, relative limit = 9.73907e-05, conv = false
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1524.81, relative limit = 0.0168566, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0123983, relative limit = 9.87762e-05, conv = false
+(0) 16:24:16 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 124.653, relative limit = 0.0160723, conv = false
+(0) 16:24:16 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00215862, relative limit = 9.88758e-05, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.2232, relative limit = 0.0161831, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000372326, relative limit = 9.88602e-05, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.73764, relative limit = 0.0161686, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.69663e-05, relative limit = 9.88622e-05, conv = true
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.397461, relative limit = 0.0161663, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.54736e-07, relative limit = 9.88625e-05, conv = true
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 40 | t 0.39 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00311781, relative limit = 0.0161662, conv = true
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18284e-07, relative limit = 9.88625e-05, conv = true
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17944.9, relative limit = 0.166456, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43955, relative limit = 0.000120329, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19318.4, relative limit = 0.0293156, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.19787, relative limit = 9.7419e-05, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1691.94, relative limit = 0.0156803, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0087504, relative limit = 9.89942e-05, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 78.9929, relative limit = 0.0153527, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00051372, relative limit = 9.90607e-05, conv = false
+(0) 16:24:17 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.0318, relative limit = 0.0153654, conv = false
+(0) 16:24:17 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.86877e-05, relative limit = 9.90569e-05, conv = true
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.82254, relative limit = 0.0153622, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21756e-06, relative limit = 9.90576e-05, conv = true
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 41 | t 0.4 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00669817, relative limit = 0.0153622, conv = true
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.02325e-06, relative limit = 9.90576e-05, conv = true
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24228.6, relative limit = 0.232407, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.5609, relative limit = 0.000131425, conv = false
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25088.8, relative limit = 0.023061, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.150505, relative limit = 9.81061e-05, conv = false
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1428.4, relative limit = 0.0147694, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0119935, relative limit = 9.94904e-05, conv = false
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 98.7228, relative limit = 0.0148479, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000375618, relative limit = 9.94025e-05, conv = false
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.68223, relative limit = 0.0148615, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.66096e-05, relative limit = 9.93997e-05, conv = true
+(0) 16:24:18 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.59192, relative limit = 0.0148622, conv = false
+(0) 16:24:18 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.09514e-06, relative limit = 9.93992e-05, conv = true
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0603464, relative limit = 0.0148624, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.17262e-07, relative limit = 9.93991e-05, conv = true
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 42 | t 0.41 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0019174, relative limit = 0.0148624, conv = true
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47377e-07, relative limit = 9.93991e-05, conv = true
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.3, relative limit = 0.27634, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36995, relative limit = 0.000139835, conv = false
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28578.6, relative limit = 0.0189749, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103466, relative limit = 9.89274e-05, conv = false
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 946.554, relative limit = 0.0150045, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00619205, relative limit = 9.9902e-05, conv = false
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 45.6101, relative limit = 0.0149009, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000788739, relative limit = 9.986e-05, conv = false
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.6417, relative limit = 0.0148796, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.27248e-05, relative limit = 9.98544e-05, conv = true
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.323842, relative limit = 0.0148814, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32238e-05, relative limit = 9.98546e-05, conv = true
+(0) 16:24:19 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.192556, relative limit = 0.0148811, conv = false
+(0) 16:24:19 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.06114e-07, relative limit = 9.98544e-05, conv = true
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 43 | t 0.42 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00731965, relative limit = 0.0148811, conv = true
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66654e-07, relative limit = 9.98544e-05, conv = true
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.5, relative limit = 0.293276, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64191, relative limit = 0.000143336, conv = false
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27680.7, relative limit = 0.0285309, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.197951, relative limit = 0.000101541, conv = false
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1539.89, relative limit = 0.015467, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00260415, relative limit = 0.000100364, conv = false
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.5455, relative limit = 0.0152306, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00372577, relative limit = 0.00010035, conv = false
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.0423, relative limit = 0.0153839, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000233202, relative limit = 0.000100377, conv = false
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47751, relative limit = 0.0153914, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.41052e-05, relative limit = 0.000100378, conv = true
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.320519, relative limit = 0.0153931, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.573e-05, relative limit = 0.000100378, conv = true
+(0) 16:24:20 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.128802, relative limit = 0.0153937, conv = false
+(0) 16:24:20 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.36891e-07, relative limit = 0.000100378, conv = true
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 44 | t 0.43 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00830216, relative limit = 0.0153937, conv = true
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.83773e-07, relative limit = 0.000100378, conv = true
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.7, relative limit = 0.281235, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29132, relative limit = 0.000140982, conv = false
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25513.1, relative limit = 0.0342668, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.249268, relative limit = 0.000102699, conv = false
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2108.15, relative limit = 0.0152754, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0152214, relative limit = 0.000100797, conv = false
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 234.075, relative limit = 0.0169206, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0128118, relative limit = 0.000101025, conv = false
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 89.9562, relative limit = 0.016284, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00207033, relative limit = 0.000100935, conv = false
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17.0116, relative limit = 0.0161623, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1279e-05, relative limit = 0.000100919, conv = true
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.352831, relative limit = 0.01616, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0513e-05, relative limit = 0.000100919, conv = true
+(0) 16:24:21 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0959922, relative limit = 0.0161606, conv = false
+(0) 16:24:21 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.86825e-07, relative limit = 0.000100919, conv = true
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 45 | t 0.44 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00886862, relative limit = 0.0161606, conv = true
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.60743e-07, relative limit = 0.000100919, conv = true
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355, relative limit = 0.241417, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42312, relative limit = 0.000133641, conv = false
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20584.7, relative limit = 0.0412985, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.318504, relative limit = 0.00010392, conv = false
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2302.15, relative limit = 0.019128, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0302063, relative limit = 0.000101657, conv = false
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 260.564, relative limit = 0.0167736, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00152303, relative limit = 0.000101408, conv = false
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4429, relative limit = 0.0168041, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000975661, relative limit = 0.000101413, conv = false
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.00355, relative limit = 0.0168761, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27474e-05, relative limit = 0.00010142, conv = true
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.233525, relative limit = 0.0168758, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.93266e-06, relative limit = 0.00010142, conv = true
+(0) 16:24:22 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0748654, relative limit = 0.0168752, conv = false
+(0) 16:24:22 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.28172e-07, relative limit = 0.00010142, conv = true
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 46 | t 0.45 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000731221, relative limit = 0.0168752, conv = true
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.61937e-08, relative limit = 0.00010142, conv = true
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178175, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26839, relative limit = 0.000123387, conv = false
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13793.2, relative limit = 0.0449312, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.349948, relative limit = 0.000104697, conv = false
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2342.47, relative limit = 0.0218396, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0572314, relative limit = 0.000102294, conv = false
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 446.877, relative limit = 0.0175229, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00298564, relative limit = 0.000101856, conv = false
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23.5805, relative limit = 0.0172991, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000118938, relative limit = 0.000101833, conv = false
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.904167, relative limit = 0.017291, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.65236e-06, relative limit = 0.000101833, conv = true
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.106918, relative limit = 0.0172903, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11179e-06, relative limit = 0.000101832, conv = true
+(0) 16:24:23 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0223278, relative limit = 0.0172904, conv = false
+(0) 16:24:23 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.27023e-07, relative limit = 0.000101832, conv = true
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 47 | t 0.46 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00459269, relative limit = 0.0172905, conv = true
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.13041e-08, relative limit = 0.000101833, conv = true
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.46, relative limit = 0.0992486, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08132, relative limit = 0.000112386, conv = false
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7061.01, relative limit = 0.0325008, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.187717, relative limit = 0.000103704, conv = false
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1385.19, relative limit = 0.0188069, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0188169, relative limit = 0.000102272, conv = false
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 108.532, relative limit = 0.0177458, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00576281, relative limit = 0.000102163, conv = false
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 44.509, relative limit = 0.0173101, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000422051, relative limit = 0.000102118, conv = false
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.26706, relative limit = 0.0172782, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.06142e-05, relative limit = 0.000102115, conv = true
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.205373, relative limit = 0.0172763, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.03961e-06, relative limit = 0.000102114, conv = true
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0556473, relative limit = 0.0172758, conv = false
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.84703e-07, relative limit = 0.000102114, conv = true
+(0) 16:24:24 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 48 | t 0.47 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00325535, relative limit = 0.0172758, conv = true
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13021e-07, relative limit = 0.000102114, conv = true
+(0) 16:24:24 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.55, relative limit = 0.0315334, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394729, relative limit = 0.000102184, conv = false
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3181.6, relative limit = 0.0221171, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0644654, relative limit = 0.000102809, conv = false
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 408.636, relative limit = 0.0180405, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0149347, relative limit = 0.00010237, conv = false
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 120.912, relative limit = 0.0168717, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000515086, relative limit = 0.000102243, conv = false
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.77738, relative limit = 0.0168172, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0001804, relative limit = 0.000102237, conv = false
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.53515, relative limit = 0.0168323, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.23938e-06, relative limit = 0.000102239, conv = true
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0564931, relative limit = 0.0168318, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37426e-06, relative limit = 0.000102239, conv = true
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 49 | t 0.48 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00935459, relative limit = 0.0168318, conv = true
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.47797e-07, relative limit = 0.000102239, conv = true
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:25 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914183, conv = false
+(0) 16:24:25 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09218, relative limit = 9.35871e-05, conv = false
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8783.03, relative limit = 0.00966598, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.172806, relative limit = 0.000100727, conv = false
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1422.28, relative limit = 0.0156883, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0077639, relative limit = 0.000102137, conv = false
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 64.3906, relative limit = 0.0160871, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.89383e-05, relative limit = 0.000102194, conv = true
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.72904, relative limit = 0.0161064, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000289833, relative limit = 0.000102196, conv = false
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.98193, relative limit = 0.0160948, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9779e-05, relative limit = 0.000102195, conv = true
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.486005, relative limit = 0.0160921, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.53389e-06, relative limit = 0.000102194, conv = true
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.070741, relative limit = 0.0160926, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02122e-06, relative limit = 0.000102195, conv = true
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 50 | t 0.49 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00665987, relative limit = 0.0160926, conv = true
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17796e-07, relative limit = 0.000102195, conv = true
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:26 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.8, relative limit = 0.169772, conv = false
+(0) 16:24:26 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16939.9, relative limit = 0.0113271, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.10699, relative limit = 0.000101041, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 811.545, relative limit = 0.014844, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0135903, relative limit = 0.000101883, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 112.331, relative limit = 0.0152977, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000383109, relative limit = 0.000101985, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.94059, relative limit = 0.0153146, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.39036e-05, relative limit = 0.000101989, conv = true
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.729126, relative limit = 0.015312, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.82546e-06, relative limit = 0.000101988, conv = true
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 51 | t 0.5 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0104172, relative limit = 0.0153121, conv = true
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.04896e-06, relative limit = 0.000101988, conv = true
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265.1, relative limit = 0.233204, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22178, relative limit = 8.20632e-05, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23373.4, relative limit = 0.0131094, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0508066, relative limit = 0.000101176, conv = false
+(0) 16:24:27 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 444.372, relative limit = 0.0147804, conv = false
+(0) 16:24:27 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00144605, relative limit = 0.000101648, conv = false
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.0661, relative limit = 0.0148052, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.02893e-05, relative limit = 0.000101641, conv = true
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.337685, relative limit = 0.0148054, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02753e-05, relative limit = 0.000101641, conv = true
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0690879, relative limit = 0.0148053, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.13729e-06, relative limit = 0.000101641, conv = true
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0160148, relative limit = 0.0148053, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.66238e-07, relative limit = 0.000101641, conv = true
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 52 | t 0.51 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00188088, relative limit = 0.0148053, conv = true
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.46349e-08, relative limit = 0.000101641, conv = true
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28162.8, relative limit = 0.0135027, conv = false
+(0) 16:24:28 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0955671, relative limit = 0.000101775, conv = false
+(0) 16:24:28 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 904.845, relative limit = 0.0150867, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0125219, relative limit = 0.000101096, conv = false
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 109.535, relative limit = 0.0148181, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000356394, relative limit = 0.000101191, conv = false
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.3726, relative limit = 0.0148126, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.07971e-05, relative limit = 0.000101189, conv = true
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.715895, relative limit = 0.0148122, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00968e-05, relative limit = 0.000101188, conv = true
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0806417, relative limit = 0.0148122, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50444e-06, relative limit = 0.000101188, conv = true
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 53 | t 0.52 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0137648, relative limit = 0.0148122, conv = true
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.35666e-07, relative limit = 0.000101188, conv = true
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.7, relative limit = 0.289551, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53904, relative limit = 7.77586e-05, conv = false
+(0) 16:24:29 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29288.7, relative limit = 0.0119449, conv = false
+(0) 16:24:29 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102303, relative limit = 0.000101365, conv = false
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 890.405, relative limit = 0.0152961, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00262658, relative limit = 0.000100652, conv = false
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.0922, relative limit = 0.0153222, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000330221, relative limit = 0.000100674, conv = false
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.06314, relative limit = 0.0153406, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.63589e-05, relative limit = 0.000100674, conv = true
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.701646, relative limit = 0.0153453, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.76982e-06, relative limit = 0.000100674, conv = true
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0425897, relative limit = 0.0153455, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.58058e-07, relative limit = 0.000100674, conv = true
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 54 | t 0.53 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00227687, relative limit = 0.0153455, conv = true
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.03077e-08, relative limit = 0.000100674, conv = true
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
+(0) 16:24:30 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28009.7, relative limit = 0.00993351, conv = false
+(0) 16:24:30 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.145537, relative limit = 0.000101214, conv = false
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1281.27, relative limit = 0.0162739, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00238994, relative limit = 0.000100126, conv = false
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19.2303, relative limit = 0.016176, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000327667, relative limit = 0.000100145, conv = false
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.7624, relative limit = 0.0161719, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.60895e-05, relative limit = 0.000100147, conv = true
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.392745, relative limit = 0.0161744, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21069e-06, relative limit = 0.000100146, conv = true
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 55 | t 0.54 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0139316, relative limit = 0.0161745, conv = true
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87095e-06, relative limit = 0.000100146, conv = true
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.8, relative limit = 0.238772, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09876, relative limit = 8.03106e-05, conv = false
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23963.7, relative limit = 0.00745901, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.162145, relative limit = 0.000100894, conv = false
+(0) 16:24:31 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1245.03, relative limit = 0.015449, conv = false
+(0) 16:24:31 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0193894, relative limit = 9.98072e-05, conv = false
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 171.353, relative limit = 0.0169524, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000189575, relative limit = 9.96567e-05, conv = false
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.30629, relative limit = 0.0169631, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.61929e-05, relative limit = 9.96564e-05, conv = true
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.212048, relative limit = 0.016965, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.4371e-06, relative limit = 9.96563e-05, conv = true
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0308893, relative limit = 0.0169652, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21367e-06, relative limit = 9.96563e-05, conv = true
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 56 | t 0.55 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00913197, relative limit = 0.0169651, conv = true
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.6125e-07, relative limit = 9.96563e-05, conv = true
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.6, relative limit = 0.177979, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59417, relative limit = 8.43403e-05, conv = false
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17535.3, relative limit = 0.00650628, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.146136, relative limit = 0.000100432, conv = false
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1178.88, relative limit = 0.0163511, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0127501, relative limit = 9.93541e-05, conv = false
+(0) 16:24:32 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 111.773, relative limit = 0.0174106, conv = false
+(0) 16:24:32 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000318598, relative limit = 9.92511e-05, conv = false
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21363, relative limit = 0.0174255, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.35467e-05, relative limit = 9.92502e-05, conv = true
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.764378, relative limit = 0.0174326, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.22604e-06, relative limit = 9.92495e-05, conv = true
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0813337, relative limit = 0.0174333, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.73498e-07, relative limit = 9.92495e-05, conv = true
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 57 | t 0.56 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00432554, relative limit = 0.0174333, conv = true
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.68283e-08, relative limit = 9.92495e-05, conv = true
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.76, relative limit = 0.101491, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905141, relative limit = 9.04188e-05, conv = false
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9591.1, relative limit = 0.00710835, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.123707, relative limit = 0.000100011, conv = false
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 930.389, relative limit = 0.0157864, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0187613, relative limit = 9.91243e-05, conv = false
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 165.992, relative limit = 0.0174035, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000273501, relative limit = 9.89672e-05, conv = false
+(0) 16:24:33 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32231, relative limit = 0.0174249, conv = false
+(0) 16:24:33 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.87102e-05, relative limit = 9.89651e-05, conv = true
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.124233, relative limit = 0.017426, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.20987e-06, relative limit = 9.89651e-05, conv = true
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0444236, relative limit = 0.0174264, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.14966e-07, relative limit = 9.8965e-05, conv = true
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 58 | t 0.57 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00347861, relative limit = 0.0174264, conv = true
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.27642e-08, relative limit = 9.8965e-05, conv = true
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.43, relative limit = 0.031697, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365143, relative limit = 9.86513e-05, conv = false
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2841.95, relative limit = 0.0122604, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0536594, relative limit = 9.93107e-05, conv = false
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 470.205, relative limit = 0.0169215, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000768161, relative limit = 9.88336e-05, conv = false
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.26883, relative limit = 0.0169191, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000374345, relative limit = 9.88343e-05, conv = false
+(0) 16:24:34 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.60885, relative limit = 0.0169445, conv = false
+(0) 16:24:34 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.96181e-05, relative limit = 9.88317e-05, conv = true
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.654463, relative limit = 0.016951, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.48326e-06, relative limit = 9.88311e-05, conv = true
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0531576, relative limit = 0.0169505, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.2397e-07, relative limit = 9.88312e-05, conv = true
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 59 | t 0.58 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00074714, relative limit = 0.0169505, conv = true
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.43708e-08, relative limit = 9.88312e-05, conv = true
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.4, relative limit = 0.0868156, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25802, relative limit = 0.000108871, conv = false
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11437.4, relative limit = 0.0304866, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.180973, relative limit = 9.7398e-05, conv = false
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1475.28, relative limit = 0.0171431, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177103, relative limit = 9.87396e-05, conv = false
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 163.944, relative limit = 0.0161081, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00147597, relative limit = 9.88707e-05, conv = false
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.4572, relative limit = 0.0161707, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.59391e-05, relative limit = 9.8862e-05, conv = true
+(0) 16:24:35 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.454782, relative limit = 0.0161667, conv = false
+(0) 16:24:35 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.01127e-05, relative limit = 9.88624e-05, conv = true
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102303, relative limit = 0.0161661, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17953e-05, relative limit = 9.88625e-05, conv = true
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.186763, relative limit = 0.0161673, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.1547e-07, relative limit = 9.88624e-05, conv = true
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 60 | t 0.59 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00225514, relative limit = 0.0161673, conv = true
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.65302e-07, relative limit = 9.88624e-05, conv = true
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17945.5, relative limit = 0.166461, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43965, relative limit = 0.00012033, conv = false
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19321.6, relative limit = 0.0293372, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.198158, relative limit = 9.74165e-05, conv = false
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1733.29, relative limit = 0.0155069, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00412816, relative limit = 9.90281e-05, conv = false
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.1334, relative limit = 0.0153201, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00139175, relative limit = 9.90672e-05, conv = false
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.6197, relative limit = 0.015365, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00010004, relative limit = 9.90569e-05, conv = false
+(0) 16:24:36 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.707521, relative limit = 0.0153636, conv = false
+(0) 16:24:36 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.4912e-05, relative limit = 9.90574e-05, conv = true
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.12354, relative limit = 0.0153631, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.71073e-07, relative limit = 9.90575e-05, conv = true
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 61 | t 0.6 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00112378, relative limit = 0.0153631, conv = true
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.87179e-07, relative limit = 9.90575e-05, conv = true
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24229.1, relative limit = 0.232411, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56098, relative limit = 0.000131426, conv = false
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25043.7, relative limit = 0.0227545, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.145344, relative limit = 9.81474e-05, conv = false
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1310.2, relative limit = 0.0147969, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00311566, relative limit = 9.9425e-05, conv = false
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28.1931, relative limit = 0.0148696, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000156813, relative limit = 9.93976e-05, conv = false
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.16732, relative limit = 0.014862, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.59954e-05, relative limit = 9.93998e-05, conv = true
+(0) 16:24:37 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.910998, relative limit = 0.0148632, conv = false
+(0) 16:24:37 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.10442e-05, relative limit = 9.93989e-05, conv = true
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0818878, relative limit = 0.0148631, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.3573e-06, relative limit = 9.9399e-05, conv = true
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 62 | t 0.61 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0115552, relative limit = 0.0148631, conv = true
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.89743e-08, relative limit = 9.9399e-05, conv = true
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.6, relative limit = 0.276342, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.37001, relative limit = 0.000139836, conv = false
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27511.3, relative limit = 0.020454, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.08535, relative limit = 9.99219e-05, conv = false
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 505.388, relative limit = 0.0156873, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0198357, relative limit = 9.99696e-05, conv = false
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 142.157, relative limit = 0.0148758, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00237361, relative limit = 9.98752e-05, conv = false
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.479, relative limit = 0.0148818, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.798e-05, relative limit = 9.98545e-05, conv = true
+(0) 16:24:38 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.373842, relative limit = 0.0148816, conv = false
+(0) 16:24:38 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.86262e-05, relative limit = 9.98546e-05, conv = true
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.346996, relative limit = 0.0148816, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.44735e-06, relative limit = 9.98543e-05, conv = true
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 63 | t 0.62 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0123028, relative limit = 0.0148816, conv = true
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.40011e-07, relative limit = 9.98543e-05, conv = true
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.8, relative limit = 0.293277, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64195, relative limit = 0.000143336, conv = false
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27733.1, relative limit = 0.0282454, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.192623, relative limit = 0.00010148, conv = false
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1338.28, relative limit = 0.0165308, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0196437, relative limit = 0.000100499, conv = false
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 141.589, relative limit = 0.0154558, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00211405, relative limit = 0.000100397, conv = false
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.6948, relative limit = 0.0153993, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000171069, relative limit = 0.00010038, conv = false
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.981399, relative limit = 0.0153956, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.61779e-05, relative limit = 0.000100379, conv = true
+(0) 16:24:39 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.442263, relative limit = 0.0153941, conv = false
+(0) 16:24:39 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.15114e-06, relative limit = 0.000100378, conv = true
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0358871, relative limit = 0.0153939, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.6911e-07, relative limit = 0.000100378, conv = true
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 64 | t 0.63 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00523848, relative limit = 0.0153939, conv = true
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11275e-07, relative limit = 0.000100378, conv = true
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.9, relative limit = 0.281236, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29135, relative limit = 0.000140982, conv = false
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24779.3, relative limit = 0.0421959, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.356939, relative limit = 0.000103491, conv = false
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2536.17, relative limit = 0.018384, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0334444, relative limit = 0.000101166, conv = false
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 233.011, relative limit = 0.0164706, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00502066, relative limit = 0.000100956, conv = false
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.4562, relative limit = 0.0162079, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000758337, relative limit = 0.000100924, conv = false
+(0) 16:24:40 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.47822, relative limit = 0.0161654, conv = false
+(0) 16:24:40 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.35452e-05, relative limit = 0.000100919, conv = true
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.707714, relative limit = 0.0161603, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.34728e-06, relative limit = 0.000100919, conv = true
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0373423, relative limit = 0.0161605, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.88452e-06, relative limit = 0.000100919, conv = true
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 65 | t 0.64 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0133246, relative limit = 0.0161606, conv = true
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86112e-07, relative limit = 0.000100919, conv = true
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355.2, relative limit = 0.241417, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42314, relative limit = 0.000133641, conv = false
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20283.1, relative limit = 0.0439114, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.352369, relative limit = 0.000104262, conv = false
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2774.27, relative limit = 0.0173835, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00812142, relative limit = 0.00010147, conv = false
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 80.6667, relative limit = 0.0166917, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00260502, relative limit = 0.000101405, conv = false
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.1517, relative limit = 0.0168727, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.16491e-05, relative limit = 0.00010142, conv = true
+(0) 16:24:41 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.548064, relative limit = 0.0168776, conv = false
+(0) 16:24:41 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10696e-05, relative limit = 0.00010142, conv = true
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.344439, relative limit = 0.0168751, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.90958e-06, relative limit = 0.00010142, conv = true
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 66 | t 0.65 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0162444, relative limit = 0.016875, conv = true
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.9403e-08, relative limit = 0.00010142, conv = true
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178175, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.2684, relative limit = 0.000123387, conv = false
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13954.4, relative limit = 0.0427673, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.321392, relative limit = 0.000104501, conv = false
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2554.88, relative limit = 0.0177386, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00769094, relative limit = 0.000101857, conv = false
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 48.4417, relative limit = 0.0174707, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00248553, relative limit = 0.000101854, conv = false
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.8176, relative limit = 0.0172839, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103749, relative limit = 0.000101832, conv = false
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.862468, relative limit = 0.0172901, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.99365e-06, relative limit = 0.000101832, conv = true
+(0) 16:24:42 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0358609, relative limit = 0.0172898, conv = false
+(0) 16:24:42 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.00101e-06, relative limit = 0.000101832, conv = true
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0477237, relative limit = 0.0172901, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.2645e-07, relative limit = 0.000101832, conv = true
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 67 | t 0.66 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00497253, relative limit = 0.0172902, conv = true
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.64993e-08, relative limit = 0.000101832, conv = true
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.53, relative limit = 0.0992488, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08133, relative limit = 0.000112386, conv = false
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6984.94, relative limit = 0.0327952, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.190294, relative limit = 0.000103774, conv = false
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1401.32, relative limit = 0.0189065, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0200521, relative limit = 0.000102287, conv = false
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 140.45, relative limit = 0.0175411, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00324763, relative limit = 0.000102142, conv = false
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 21.7349, relative limit = 0.017328, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000648293, relative limit = 0.00010212, conv = false
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.2428, relative limit = 0.017277, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.35835e-05, relative limit = 0.000102115, conv = true
+(0) 16:24:43 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.187753, relative limit = 0.0172753, conv = false
+(0) 16:24:43 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.45005e-07, relative limit = 0.000102114, conv = true
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 68 | t 0.67 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00359162, relative limit = 0.0172753, conv = true
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.67789e-08, relative limit = 0.000102114, conv = true
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.54, relative limit = 0.0315334, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394728, relative limit = 0.000102184, conv = false
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3159.67, relative limit = 0.0222344, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0654906, relative limit = 0.000102837, conv = false
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 514.564, relative limit = 0.0171354, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00537271, relative limit = 0.000102272, conv = false
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.3076, relative limit = 0.0167962, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000534955, relative limit = 0.000102234, conv = false
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.48801, relative limit = 0.0168304, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.39532e-05, relative limit = 0.000102239, conv = true
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.340412, relative limit = 0.0168331, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.21158e-05, relative limit = 0.000102239, conv = true
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.123641, relative limit = 0.0168319, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.24081e-06, relative limit = 0.000102239, conv = true
+(0) 16:24:44 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0532008, relative limit = 0.0168314, conv = false
+(0) 16:24:44 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.54534e-07, relative limit = 0.000102239, conv = true
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 69 | t 0.68 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00519937, relative limit = 0.0168313, conv = true
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.24689e-07, relative limit = 0.000102239, conv = true
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914182, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09217, relative limit = 9.35871e-05, conv = false
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8800.62, relative limit = 0.00976083, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.170563, relative limit = 0.000100751, conv = false
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1399.46, relative limit = 0.0157098, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00844864, relative limit = 0.000102137, conv = false
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 68.5825, relative limit = 0.0160882, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000146633, relative limit = 0.000102194, conv = false
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27675, relative limit = 0.0160926, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.68457e-05, relative limit = 0.000102195, conv = true
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0650567, relative limit = 0.0160926, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.21302e-06, relative limit = 0.000102195, conv = true
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.07695, relative limit = 0.0160922, conv = false
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.54522e-07, relative limit = 0.000102194, conv = true
+(0) 16:24:45 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 70 | t 0.69 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00144794, relative limit = 0.0160922, conv = true
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.6135e-08, relative limit = 0.000102194, conv = true
+(0) 16:24:45 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.7, relative limit = 0.169772, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16853.3, relative limit = 0.0115918, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.116411, relative limit = 0.000100965, conv = false
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1044.47, relative limit = 0.0154982, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0048847, relative limit = 0.000102025, conv = false
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 35.8941, relative limit = 0.0153342, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000667514, relative limit = 0.000101993, conv = false
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.04465, relative limit = 0.0153141, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.36006e-05, relative limit = 0.000101988, conv = true
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.57744, relative limit = 0.015312, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.53508e-06, relative limit = 0.000101988, conv = true
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0571211, relative limit = 0.0153118, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.29515e-06, relative limit = 0.000101988, conv = true
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 71 | t 0.7 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0102031, relative limit = 0.0153118, conv = true
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.29984e-08, relative limit = 0.000101988, conv = true
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:46 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265, relative limit = 0.233204, conv = false
+(0) 16:24:46 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22177, relative limit = 8.20633e-05, conv = false
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23365.9, relative limit = 0.0131086, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0515999, relative limit = 0.000101169, conv = false
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 458.643, relative limit = 0.0147919, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00228458, relative limit = 0.000101655, conv = false
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.4522, relative limit = 0.0148043, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.3059e-05, relative limit = 0.000101641, conv = true
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.59827, relative limit = 0.0148056, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41986e-05, relative limit = 0.000101641, conv = true
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.200931, relative limit = 0.0148051, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.31855e-06, relative limit = 0.000101641, conv = true
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 72 | t 0.71 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00938826, relative limit = 0.0148051, conv = true
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.75791e-07, relative limit = 0.000101641, conv = true
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
+(0) 16:24:47 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28478.8, relative limit = 0.0142547, conv = false
+(0) 16:24:47 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.139344, relative limit = 0.000102026, conv = false
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1207.48, relative limit = 0.0148996, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00556548, relative limit = 0.000101143, conv = false
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 44.3611, relative limit = 0.0148095, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000580576, relative limit = 0.000101184, conv = false
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.46464, relative limit = 0.014809, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000106998, relative limit = 0.000101189, conv = false
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.814369, relative limit = 0.0148117, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0902e-05, relative limit = 0.000101188, conv = true
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.099174, relative limit = 0.014812, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.79176e-07, relative limit = 0.000101188, conv = true
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 73 | t 0.72 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00707705, relative limit = 0.014812, conv = true
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.08443e-07, relative limit = 0.000101188, conv = true
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.7, relative limit = 0.289552, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53904, relative limit = 7.77586e-05, conv = false
+(0) 16:24:48 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28962.6, relative limit = 0.0120986, conv = false
+(0) 16:24:48 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0639521, relative limit = 0.000101049, conv = false
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 441.464, relative limit = 0.0146258, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.012013, relative limit = 0.000100741, conv = false
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 98.681, relative limit = 0.0153163, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00044688, relative limit = 0.000100675, conv = false
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.32337, relative limit = 0.0153444, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.49468e-05, relative limit = 0.000100674, conv = true
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.257273, relative limit = 0.0153455, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.27263e-06, relative limit = 0.000100674, conv = true
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0600978, relative limit = 0.0153455, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.70954e-06, relative limit = 0.000100674, conv = true
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 74 | t 0.73 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0136432, relative limit = 0.0153455, conv = true
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.64231e-07, relative limit = 0.000100674, conv = true
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27648.8, relative limit = 0.0103064, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103319, relative limit = 0.000100869, conv = false
+(0) 16:24:49 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 915.599, relative limit = 0.0163205, conv = false
+(0) 16:24:49 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0022522, relative limit = 0.00010013, conv = false
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.2175, relative limit = 0.0161873, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00026052, relative limit = 0.000100146, conv = false
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.07887, relative limit = 0.0161741, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11817e-05, relative limit = 0.000100147, conv = true
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.30505, relative limit = 0.0161752, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.30994e-05, relative limit = 0.000100146, conv = true
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.102214, relative limit = 0.0161745, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5991e-06, relative limit = 0.000100146, conv = true
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 75 | t 0.74 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0134354, relative limit = 0.0161744, conv = true
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32901e-07, relative limit = 0.000100146, conv = true
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.8, relative limit = 0.238773, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09876, relative limit = 8.03106e-05, conv = false
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23791.8, relative limit = 0.00832783, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.139262, relative limit = 0.000100747, conv = false
+(0) 16:24:50 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1236.78, relative limit = 0.0170458, conv = false
+(0) 16:24:50 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00112554, relative limit = 9.96464e-05, conv = false
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.61411, relative limit = 0.0169841, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000282565, relative limit = 9.96538e-05, conv = false
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.05392, relative limit = 0.0169682, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.87406e-05, relative limit = 9.96558e-05, conv = true
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.473259, relative limit = 0.0169655, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.66456e-06, relative limit = 9.96562e-05, conv = true
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0605439, relative limit = 0.0169651, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.52965e-07, relative limit = 9.96563e-05, conv = true
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 76 | t 0.75 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00129318, relative limit = 0.0169651, conv = true
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26644e-08, relative limit = 9.96563e-05, conv = true
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.7, relative limit = 0.17798, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59418, relative limit = 8.43402e-05, conv = false
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17609.5, relative limit = 0.00587415, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.1555, relative limit = 0.000100499, conv = false
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1113.99, relative limit = 0.0150222, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0286098, relative limit = 9.94841e-05, conv = false
+(0) 16:24:51 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 239.221, relative limit = 0.0172641, conv = false
+(0) 16:24:51 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00204189, relative limit = 9.92631e-05, conv = false
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15.8035, relative limit = 0.0174136, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000235351, relative limit = 9.92511e-05, conv = false
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.95149, relative limit = 0.0174322, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.369e-05, relative limit = 9.92496e-05, conv = true
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.122526, relative limit = 0.0174333, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.27678e-07, relative limit = 9.92494e-05, conv = true
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 77 | t 0.76 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00247565, relative limit = 0.0174333, conv = true
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.01561e-08, relative limit = 9.92494e-05, conv = true
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.84, relative limit = 0.101492, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905148, relative limit = 9.04187e-05, conv = false
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9631.34, relative limit = 0.00685574, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.126871, relative limit = 0.000100056, conv = false
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 989.405, relative limit = 0.0160652, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0155815, relative limit = 9.90952e-05, conv = false
+(0) 16:24:52 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 130.842, relative limit = 0.0173447, conv = false
+(0) 16:24:52 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000932428, relative limit = 9.89727e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.40208, relative limit = 0.0174171, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000111589, relative limit = 9.89658e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00718, relative limit = 0.0174267, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.79494e-06, relative limit = 9.8965e-05, conv = true
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0291285, relative limit = 0.0174264, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.58032e-06, relative limit = 9.8965e-05, conv = true
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 78 | t 0.77 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0144153, relative limit = 0.0174265, conv = true
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.24503e-08, relative limit = 9.8965e-05, conv = true
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.4, relative limit = 0.0316973, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365139, relative limit = 9.86512e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2894.77, relative limit = 0.0132148, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0452231, relative limit = 9.92103e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 338.725, relative limit = 0.0164984, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00589512, relative limit = 9.88749e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.8269, relative limit = 0.0169103, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000611119, relative limit = 9.88348e-05, conv = false
+(0) 16:24:53 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.93456, relative limit = 0.0169429, conv = false
+(0) 16:24:53 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103162, relative limit = 9.88319e-05, conv = false
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.927373, relative limit = 0.0169517, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27932e-05, relative limit = 9.8831e-05, conv = true
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110344, relative limit = 0.0169506, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.03882e-06, relative limit = 9.88311e-05, conv = true
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 79 | t 0.78 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0109412, relative limit = 0.0169506, conv = true
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.12079e-07, relative limit = 9.88311e-05, conv = true
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.3, relative limit = 0.0868145, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25801, relative limit = 0.000108871, conv = false
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11463, relative limit = 0.0307657, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.183738, relative limit = 9.7371e-05, conv = false
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1530.2, relative limit = 0.0169498, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.014237, relative limit = 9.87632e-05, conv = false
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 145.05, relative limit = 0.0160278, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00265679, relative limit = 9.8881e-05, conv = false
+(0) 16:24:54 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 20.8738, relative limit = 0.0161557, conv = false
+(0) 16:24:54 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000220897, relative limit = 9.88639e-05, conv = false
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.45017, relative limit = 0.0161646, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.09995e-05, relative limit = 9.88627e-05, conv = true
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.504661, relative limit = 0.0161678, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.58755e-06, relative limit = 9.88623e-05, conv = true
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0638141, relative limit = 0.0161674, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.73947e-07, relative limit = 9.88624e-05, conv = true
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 80 | t 0.79 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000988149, relative limit = 0.0161674, conv = true
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.67428e-08, relative limit = 9.88624e-05, conv = true
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17945.4, relative limit = 0.16646, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.43963, relative limit = 0.000120329, conv = false
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19323.1, relative limit = 0.0293491, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.198343, relative limit = 9.74155e-05, conv = false
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1735.23, relative limit = 0.0155104, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00409305, relative limit = 9.90279e-05, conv = false
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.6085, relative limit = 0.015364, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.11319e-05, relative limit = 9.90572e-05, conv = true
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.502432, relative limit = 0.0153663, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000103292, relative limit = 9.90567e-05, conv = false
+(0) 16:24:55 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.741035, relative limit = 0.0153638, conv = false
+(0) 16:24:55 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.5316e-05, relative limit = 9.90574e-05, conv = true
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.119901, relative limit = 0.0153633, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.21223e-06, relative limit = 9.90575e-05, conv = true
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 81 | t 0.8 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00785486, relative limit = 0.0153632, conv = true
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.14097e-07, relative limit = 9.90575e-05, conv = true
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24228.9, relative limit = 0.23241, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56095, relative limit = 0.000131425, conv = false
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25055.2, relative limit = 0.0228472, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.14661, relative limit = 9.81358e-05, conv = false
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1303.4, relative limit = 0.0148248, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00103787, relative limit = 9.94084e-05, conv = false
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.64782, relative limit = 0.0148618, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000366121, relative limit = 9.94016e-05, conv = false
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.20273, relative limit = 0.0148635, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.61423e-05, relative limit = 9.93989e-05, conv = true
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0849012, relative limit = 0.0148633, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.69752e-06, relative limit = 9.93989e-05, conv = true
+(0) 16:24:56 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0458667, relative limit = 0.0148632, conv = false
+(0) 16:24:56 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.36342e-06, relative limit = 9.9399e-05, conv = true
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 82 | t 0.81 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0119217, relative limit = 0.0148632, conv = true
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.1747e-08, relative limit = 9.9399e-05, conv = true
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28213.5, relative limit = 0.276341, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.36998, relative limit = 0.000139835, conv = false
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27256.8, relative limit = 0.0211773, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.104295, relative limit = 0.000100177, conv = false
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 591.186, relative limit = 0.0159742, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0249603, relative limit = 9.99904e-05, conv = false
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 165.645, relative limit = 0.015014, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00400023, relative limit = 9.98797e-05, conv = false
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 26.8197, relative limit = 0.0148877, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000708038, relative limit = 9.98602e-05, conv = false
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.9146, relative limit = 0.0148816, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.91734e-05, relative limit = 9.98544e-05, conv = true
+(0) 16:24:57 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.115991, relative limit = 0.0148819, conv = false
+(0) 16:24:57 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08103e-05, relative limit = 9.98544e-05, conv = true
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.09545, relative limit = 0.0148816, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.06817e-07, relative limit = 9.98543e-05, conv = true
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 83 | t 0.82 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00610218, relative limit = 0.0148817, conv = true
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.42307e-07, relative limit = 9.98543e-05, conv = true
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29443.6, relative limit = 0.293276, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.64193, relative limit = 0.000143336, conv = false
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27648.9, relative limit = 0.0283322, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.19719, relative limit = 0.000101589, conv = false
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1567.22, relative limit = 0.0152153, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00373635, relative limit = 0.000100356, conv = false
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 34.333, relative limit = 0.0154122, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000644774, relative limit = 0.000100384, conv = false
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.58197, relative limit = 0.0153933, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27164e-05, relative limit = 0.000100378, conv = true
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0824421, relative limit = 0.0153936, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.34581e-06, relative limit = 0.000100378, conv = true
+(0) 16:24:58 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0309993, relative limit = 0.0153938, conv = false
+(0) 16:24:58 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.50615e-06, relative limit = 0.000100378, conv = true
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 84 | t 0.83 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0091501, relative limit = 0.0153939, conv = true
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.87646e-07, relative limit = 0.000100378, conv = true
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27767.8, relative limit = 0.281235, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.29132, relative limit = 0.000140981, conv = false
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24721.3, relative limit = 0.0420136, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.35497, relative limit = 0.000103571, conv = false
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3002.89, relative limit = 0.0149607, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.022886, relative limit = 0.000100724, conv = false
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 167.285, relative limit = 0.0159696, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00319296, relative limit = 0.000100893, conv = false
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.1793, relative limit = 0.0160861, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00125686, relative limit = 0.000100908, conv = false
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.3717, relative limit = 0.0161594, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.8362e-05, relative limit = 0.000100918, conv = true
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.183787, relative limit = 0.0161608, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.7156e-06, relative limit = 0.000100919, conv = true
+(0) 16:24:59 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.037756, relative limit = 0.0161605, conv = false
+(0) 16:24:59 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.17774e-07, relative limit = 0.000100919, conv = true
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 85 | t 0.84 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000993805, relative limit = 0.0161605, conv = true
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.607e-08, relative limit = 0.000100919, conv = true
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23355.1, relative limit = 0.241416, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.42312, relative limit = 0.000133641, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19385.2, relative limit = 0.0540254, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.487246, relative limit = 0.000105295, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3428.23, relative limit = 0.020704, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0510835, relative limit = 0.000101822, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 499.765, relative limit = 0.0161782, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00963021, relative limit = 0.000101342, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 77.0596, relative limit = 0.0168465, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000410747, relative limit = 0.000101417, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.37074, relative limit = 0.0168559, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000258513, relative limit = 0.000101418, conv = false
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.8222, relative limit = 0.0168723, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.56902e-05, relative limit = 0.00010142, conv = true
+(0) 16:25:00 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.24375, relative limit = 0.0168745, conv = false
+(0) 16:25:00 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.9979e-06, relative limit = 0.00010142, conv = true
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.042872, relative limit = 0.0168749, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.87088e-07, relative limit = 0.00010142, conv = true
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 10 of 100 | dt# 86 | t 0.85 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00442773, relative limit = 0.0168749, conv = true
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.55273e-08, relative limit = 0.00010142, conv = true
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16693.5, relative limit = 0.178174, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.26838, relative limit = 0.000123387, conv = false
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13413.5, relative limit = 0.0487102, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.39833, relative limit = 0.00010514, conv = false
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2746.52, relative limit = 0.0216262, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0548412, relative limit = 0.000102271, conv = false
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 440.913, relative limit = 0.0173811, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00123964, relative limit = 0.000101841, conv = false
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 13.2118, relative limit = 0.0172593, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00039918, relative limit = 0.000101829, conv = false
+(0) 16:25:01 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.19854, relative limit = 0.0172894, conv = false
+(0) 16:25:01 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.14944e-05, relative limit = 0.000101832, conv = true
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.10604, relative limit = 0.0172901, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.18241e-06, relative limit = 0.000101832, conv = true
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 87 | t 0.86 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0138649, relative limit = 0.0172899, conv = true
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.59269e-07, relative limit = 0.000101832, conv = true
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8651.47, relative limit = 0.0992479, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.08132, relative limit = 0.000112386, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6824.89, relative limit = 0.0357724, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.229532, relative limit = 0.000104025, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1765.75, relative limit = 0.0182943, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0133708, relative limit = 0.000102214, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 60.507, relative limit = 0.0177723, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00613668, relative limit = 0.000102166, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 47.8117, relative limit = 0.017308, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000402456, relative limit = 0.000102118, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.49667, relative limit = 0.0172837, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000105693, relative limit = 0.000102115, conv = false
+(0) 16:25:02 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.792847, relative limit = 0.017276, conv = false
+(0) 16:25:02 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.11202e-05, relative limit = 0.000102114, conv = true
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0886042, relative limit = 0.0172751, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.76932e-07, relative limit = 0.000102114, conv = true
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 88 | t 0.87 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00433956, relative limit = 0.0172751, conv = true
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.7827e-08, relative limit = 0.000102114, conv = true
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3461.55, relative limit = 0.0315332, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.394729, relative limit = 0.000102184, conv = false
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2968.19, relative limit = 0.0204764, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0499442, relative limit = 0.000102631, conv = false
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 341.649, relative limit = 0.0173717, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00657775, relative limit = 0.000102297, conv = false
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 43.9617, relative limit = 0.0169348, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00127784, relative limit = 0.00010225, conv = false
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.1419, relative limit = 0.0168244, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.48923e-05, relative limit = 0.000102238, conv = true
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.655876, relative limit = 0.01683, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.58093e-05, relative limit = 0.000102239, conv = true
+(0) 16:25:03 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.121965, relative limit = 0.0168311, conv = false
+(0) 16:25:03 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.86852e-06, relative limit = 0.000102239, conv = true
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 89 | t 0.88 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0135145, relative limit = 0.016831, conv = true
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.10458e-07, relative limit = 0.000102239, conv = true
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10571.1, relative limit = 0.0914187, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.09217, relative limit = 9.35871e-05, conv = false
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8759.02, relative limit = 0.0097688, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.175506, relative limit = 0.000100706, conv = false
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1477.69, relative limit = 0.0159028, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00383773, relative limit = 0.000102168, conv = false
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 25.9793, relative limit = 0.0160521, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000708645, relative limit = 0.000102189, conv = false
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.46117, relative limit = 0.0160944, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.709e-05, relative limit = 0.000102195, conv = true
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.552487, relative limit = 0.0160916, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.90047e-06, relative limit = 0.000102194, conv = true
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.027427, relative limit = 0.0160918, conv = false
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.70862e-07, relative limit = 0.000102194, conv = true
+(0) 16:25:04 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 90 | t 0.89 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00591919, relative limit = 0.0160918, conv = true
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.50128e-07, relative limit = 0.000102194, conv = true
+(0) 16:25:04 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18242.7, relative limit = 0.169772, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.75994, relative limit = 8.68784e-05, conv = false
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16812.5, relative limit = 0.011785, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.120912, relative limit = 0.000100932, conv = false
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1112.28, relative limit = 0.015572, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00868592, relative limit = 0.000102049, conv = false
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 63.1058, relative limit = 0.0153345, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00117436, relative limit = 0.000101995, conv = false
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10.3638, relative limit = 0.0153074, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.59545e-05, relative limit = 0.000101987, conv = true
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.967759, relative limit = 0.0153123, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.86262e-05, relative limit = 0.000101988, conv = true
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.230681, relative limit = 0.0153115, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.13326e-06, relative limit = 0.000101988, conv = true
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 91 | t 0.9 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0098631, relative limit = 0.0153115, conv = true
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.00504e-07, relative limit = 0.000101988, conv = true
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:05 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 24265, relative limit = 0.233204, conv = false
+(0) 16:25:05 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.22177, relative limit = 8.20632e-05, conv = false
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23371.8, relative limit = 0.0131062, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0509535, relative limit = 0.000101174, conv = false
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 449.506, relative limit = 0.0147799, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00195568, relative limit = 0.000101652, conv = false
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 19.4196, relative limit = 0.0148057, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000390384, relative limit = 0.000101638, conv = false
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.55431, relative limit = 0.0148048, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11102e-05, relative limit = 0.000101641, conv = true
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.216465, relative limit = 0.0148049, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 5.49644e-06, relative limit = 0.000101641, conv = true
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0429661, relative limit = 0.0148048, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.99237e-07, relative limit = 0.000101641, conv = true
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 92 | t 0.91 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00406805, relative limit = 0.0148048, conv = true
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11112e-08, relative limit = 0.000101641, conv = true
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:06 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27972.8, relative limit = 0.274447, conv = false
+(0) 16:25:06 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.47794, relative limit = 7.90512e-05, conv = false
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 28340.7, relative limit = 0.0140473, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.118028, relative limit = 0.000101932, conv = false
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1016.63, relative limit = 0.0148599, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00309635, relative limit = 0.000101163, conv = false
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 18.894, relative limit = 0.0148228, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000919879, relative limit = 0.00010118, conv = false
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.73104, relative limit = 0.0148125, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.85535e-05, relative limit = 0.000101188, conv = true
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.37435, relative limit = 0.0148118, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 4.65464e-06, relative limit = 0.000101188, conv = true
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0392767, relative limit = 0.0148119, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.11171e-07, relative limit = 0.000101188, conv = true
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 93 | t 0.92 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00188154, relative limit = 0.0148119, conv = true
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.94563e-08, relative limit = 0.000101188, conv = true
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29016.6, relative limit = 0.289551, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.53903, relative limit = 7.77586e-05, conv = false
+(0) 16:25:07 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29488.3, relative limit = 0.0118251, conv = false
+(0) 16:25:07 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.127802, relative limit = 0.000101532, conv = false
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1126.09, relative limit = 0.0155063, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00412924, relative limit = 0.00010064, conv = false
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 37.7208, relative limit = 0.0153369, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000190419, relative limit = 0.000100675, conv = false
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.972375, relative limit = 0.0153419, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.04855e-05, relative limit = 0.000100674, conv = true
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.726406, relative limit = 0.0153456, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.71056e-06, relative limit = 0.000100674, conv = true
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0295317, relative limit = 0.0153454, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.14972e-07, relative limit = 0.000100674, conv = true
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 94 | t 0.93 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00731915, relative limit = 0.0153454, conv = true
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.02684e-07, relative limit = 0.000100674, conv = true
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27315.5, relative limit = 0.27723, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.41237, relative limit = 7.81603e-05, conv = false
+(0) 16:25:08 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 27733.4, relative limit = 0.0101506, conv = false
+(0) 16:25:08 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.112516, relative limit = 0.000100951, conv = false
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 915.9, relative limit = 0.0157293, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00702024, relative limit = 0.000100203, conv = false
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 61.6426, relative limit = 0.0161672, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000110645, relative limit = 0.000100147, conv = false
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.917163, relative limit = 0.0161742, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.0559e-05, relative limit = 0.000100146, conv = true
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0889366, relative limit = 0.0161747, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.39963e-06, relative limit = 0.000100146, conv = true
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 95 | t 0.94 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0157367, relative limit = 0.0161746, conv = true
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 6.4986e-07, relative limit = 0.000100146, conv = true
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23046.7, relative limit = 0.238773, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.09875, relative limit = 8.03106e-05, conv = false
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 23913.9, relative limit = 0.00780162, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.154417, relative limit = 0.000100857, conv = false
+(0) 16:25:09 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1335.75, relative limit = 0.016779, conv = false
+(0) 16:25:09 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00238934, relative limit = 9.96725e-05, conv = false
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.20818, relative limit = 0.0168268, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00173867, relative limit = 9.96696e-05, conv = false
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 15.186, relative limit = 0.0169626, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.41059e-05, relative limit = 9.96564e-05, conv = true
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.300952, relative limit = 0.0169654, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.47907e-07, relative limit = 9.96562e-05, conv = true
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 96 | t 0.95 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00548677, relative limit = 0.0169653, conv = true
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.00251e-07, relative limit = 9.96562e-05, conv = true
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16639.7, relative limit = 0.177979, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.59417, relative limit = 8.43403e-05, conv = false
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 17568, relative limit = 0.00632324, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.148557, relative limit = 0.000100466, conv = false
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1301.83, relative limit = 0.0173238, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00137997, relative limit = 9.92576e-05, conv = false
+(0) 16:25:10 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11.5233, relative limit = 0.0174281, conv = false
+(0) 16:25:10 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.29574e-05, relative limit = 9.92502e-05, conv = true
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.732333, relative limit = 0.0174326, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.22155e-05, relative limit = 9.92495e-05, conv = true
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0924599, relative limit = 0.0174335, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.69548e-06, relative limit = 9.92494e-05, conv = true
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 97 | t 0.96 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0163035, relative limit = 0.0174336, conv = true
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.15014e-07, relative limit = 9.92494e-05, conv = true
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8843.77, relative limit = 0.101492, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.905141, relative limit = 9.04188e-05, conv = false
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9624.98, relative limit = 0.0067678, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.127519, relative limit = 0.000100045, conv = false
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 973.323, relative limit = 0.0158772, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0177599, relative limit = 9.9112e-05, conv = false
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 142.468, relative limit = 0.0172677, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00182748, relative limit = 9.89799e-05, conv = false
+(0) 16:25:11 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 16.0335, relative limit = 0.0174237, conv = false
+(0) 16:25:11 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.70899e-05, relative limit = 9.89653e-05, conv = true
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.3336, relative limit = 0.0174269, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.34157e-06, relative limit = 9.8965e-05, conv = true
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0204303, relative limit = 0.0174271, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.29797e-06, relative limit = 9.89649e-05, conv = true
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0212253, relative limit = 0.0174269, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 9.95804e-08, relative limit = 9.8965e-05, conv = true
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 9 of 100 | dt# 98 | t 0.97 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000712893, relative limit = 0.0174269, conv = true
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.82199e-08, relative limit = 9.8965e-05, conv = true
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3289.41, relative limit = 0.0316973, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.365141, relative limit = 9.86512e-05, conv = false
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2831.42, relative limit = 0.0124143, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0521791, relative limit = 9.92826e-05, conv = false
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 409.239, relative limit = 0.016489, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00535718, relative limit = 9.8878e-05, conv = false
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 32.5214, relative limit = 0.0168091, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00162768, relative limit = 9.88455e-05, conv = false
+(0) 16:25:12 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 12.12, relative limit = 0.0169289, conv = false
+(0) 16:25:12 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000252931, relative limit = 9.88333e-05, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.32426, relative limit = 0.016952, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.27781e-05, relative limit = 9.8831e-05, conv = true
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.110313, relative limit = 0.0169509, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 8.83737e-07, relative limit = 9.88311e-05, conv = true
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 99 | t 0.98 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00547146, relative limit = 0.016951, conv = true
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 2.18028e-07, relative limit = 9.88311e-05, conv = true
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete yes | write-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 10134.3, relative limit = 0.0868148, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.25801, relative limit = 0.000108871, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 2 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 11451.9, relative limit = 0.030652, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.182518, relative limit = 9.73814e-05, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 3 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1501.78, relative limit = 0.0170542, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.0164046, relative limit = 9.87507e-05, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 4 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 108.952, relative limit = 0.0163586, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00368877, relative limit = 9.88373e-05, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 5 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 29.972, relative limit = 0.0161765, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.000175792, relative limit = 9.88611e-05, conv = false
+(0) 16:25:13 [impl::SolverInterfaceImpl]:379 in advance: [0mit 6 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.39575, relative limit = 0.0161683, conv = false
+(0) 16:25:13 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 1.19705e-05, relative limit = 9.88622e-05, conv = true
+(0) 16:25:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 7 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.103053, relative limit = 0.0161678, conv = false
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 3.66912e-07, relative limit = 9.88623e-05, conv = true
+(0) 16:25:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 8 of 100 | dt# 100 | t 0.99 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | read-iteration-checkpoint | 
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 0.00375526, relative limit = 0.0161678, conv = true
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:555 in measureConvergence: [0mrelative convergence measure: two-norm diff = 7.89429e-08, relative limit = 9.88623e-05, conv = true
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:559 in measureConvergence: [0mAll converged
+(0) 16:25:14 [cplscheme::BaseCouplingScheme]:212 in advance: [0mTime window completed
+(0) 16:25:14 [impl::SolverInterfaceImpl]:379 in advance: [0mit 1 of 100 | dt# 101 | t 1 of 1 | dt 0.01 | max dt 0.01 | ongoing no | dt complete yes | 
 Starting Structure Solver...
 N: 100
 Configure preCICE...


### PR DESCRIPTION
A recent preCICE update has led to changes in the output logs of the elastictube tests.

This also fixes a bug with the ownership of the Output folder, which can cause crashes during the final file copying step of the test. 