### PR TITLE
Change namings to new dealii solver namings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ jobs:
     - name: "openFOAM adapter [PETSc] [Job failure permitted]"
     - name: "CalculiX adapter [PETSc] [Job failure permitted]"
     - name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI] [Job failure permitted]"
-    - name: "[16.04] deal.ii adapter [Job failure permitted]"
     - name: "[16.04] SU2 <-> Calculix [unstable][Job failure permitted]"
 
   include:
@@ -176,7 +175,7 @@ jobs:
           echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin &&
           python push_adapter.py --dockerfile adapters/Dockerfile.calculix-adapter --operating-system ubuntu1604 --precice-installation home --docker-username $DOCKER_USERNAME
 
-    - name: "[16.04] deal.ii adapter [Job failure permitted]"
+    - name: "[16.04] deal.ii adapter"
       if: fork = false
       script:
         - python build_adapter.py --dockerfile adapters/Dockerfile.dealii-adapter --operating-system ubuntu1604 --precice-installation home --docker-username $DOCKER_USERNAME

--- a/adapters/Dockerfile.dealii-adapter
+++ b/adapters/Dockerfile.dealii-adapter
@@ -12,7 +12,7 @@ WORKDIR /home/precice
 RUN mkdir -p Logs Data/Input Data/Output Data/Exchange
 ARG branch=develop
 RUN git clone --branch $branch https://github.com/precice/dealii-adapter.git
-RUN cd dealii-adapter/coupled_elasto_dynamics/ && \
+RUN cd dealii-adapter/linear_elasticity/ && \
     cmake -DDEAL_II_DIR=$HOME/dealii -DDIM=3 -DCMAKE_BUILD_TYPE=Release . && \
     make -j $(nproc)
 

--- a/tests/TestCompose_dealii-of.Ubuntu1604.home/docker-compose.yml
+++ b/tests/TestCompose_dealii-of.Ubuntu1604.home/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command: >
       /bin/bash -c "
       ln -sf configs/* . &&
-      ./coupled_elasto_dynamics/coupled_elasto_dynamics /home/precice/Data/Input/parameters.prm"
+      ./linear_elasticity/linear_elasticity /home/precice/Data/Input/parameters.prm"
     container_name: dealii-adapter
     depends_on:
       - tutorial-data

--- a/tests/TestCompose_dealii-of.Ubuntu1604.home/docker-compose.yml
+++ b/tests/TestCompose_dealii-of.Ubuntu1604.home/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command: >
       /bin/bash -c "
       ln -sf configs/* . &&
-      ./linear_elasticity/linear_elasticity /home/precice/Data/Input/parameters.prm"
+      ./linear_elasticity/linear_elasticity /home/precice/Data/Input/linear_elasticity.prm"
     container_name: dealii-adapter
     depends_on:
       - tutorial-data


### PR DESCRIPTION
For consistency, we needed to change the naming again according to the new dealii solver (https://github.com/precice/dealii-adapter/pull/25). We have now a test for the linear solver. 

The new dealii adapter has now two coupled solvers. We should add a test for the nonlinear solver as well in a future PR.

We changed `coupled_elasto_dynamics` -> `linear_elasticity`