### PR TITLE
Update deal.ii solver to v9.2

### DIFF
--- a/solvers/Dockerfile.dealii
+++ b/solvers/Dockerfile.dealii
@@ -12,11 +12,11 @@ RUN apt-get -qq update && apt-get -qq install \
     wget && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/dealii/dealii/releases/download/v9.1.1/dealii-9.1.1.tar.gz && \
-    tar xf dealii-9.1.1.tar.gz && \
-    cd dealii-9.1.1/ && \
+RUN wget https://github.com/dealii/dealii/releases/download/v9.2.0/dealii-9.2.0.tar.gz && \
+    tar xf dealii-9.2.0.tar.gz && \
+    cd dealii-9.2.0/ && \
     mkdir build && \
     cd build && \
     cmake -DDEAL_II_COMPONENT_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=$HOME/dealii -DCMAKE_BUILD_TYPE=Release .. && \
-    make install && \ 
-    rm -r /dealii-9.1.1
+    make install && \
+    rm -r /dealii-9.2.0


### PR DESCRIPTION
See https://github.com/precice/dealii-adapter/pull/26#issuecomment-643730973.

Note that the code change in itself has no effect, since this only updates the related dockerfile in the solvers folder. The solver dockerfiles are not in active use, but are instead used for one-time uploads of a docker image to the hub (this was already done manually).