### PR TITLE
Patch referenceOutput for 1dtube tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -334,12 +334,12 @@ jobs:
     - name: "[16.04] Elastictube1D - Python"
       script:
         - python system_testing.py -s 1dtube_py -v
-        - python push.py --test 1dtube_py
+        - python push.py --test 1dtube_py -o
 
     - name: "[16.04] Elastictube1D - C++"
       script:
         - python system_testing.py -s 1dtube_cxx -v
-        - python push.py --test 1dtube_cxx
+        - python push.py --test 1dtube_cxx -o
 
     - name: "[16.04 PETSc] OpenFOAM <-> CalculiX [FSI] [Job failure permitted]"
       script:

--- a/compare_results.sh
+++ b/compare_results.sh
@@ -67,7 +67,10 @@ if [ -n "$diff_files" ]; then
     num_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]\|[vV]ersion/d'
     # Filter for text lines. Compare these seperately from numerical lines
     # Ignore any timestamps
-    txt_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]/!d; s/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]//g; s/[0-9][0-9]\/[0-9][0-9]\/[0-9][0-9][0-9][0-9]//g; /Timestamp\|[rR]untime\|[vV]ersion\|[rR]evision\|Unexpected end of/d; /Run finished/q'
+    txt_filter='s/(\|)\||\|>\|<//g; /[a-df-zA-Z]/!d; s/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]//g;
+                s/\[.\+\]:[0-9]\+//g; s/[0-9][0-9]\/[0-9][0-9]\/[0-9][0-9][0-9][0-9]//g;
+                /Timestamp\|[rR]untime\|[vV]ersion\|[rR]evision\|Unexpected end of/d; /Run finished/q'
+
     file1_num=$( cat "$file1" | sed "$num_filter")
     file2_num=$( cat "$file2" | sed "$num_filter")
 


### PR DESCRIPTION
The added exceptions (#233) have revealed that the 1dtube tests are currently crashing due discrepancies in the output.

It turns out that the line numbers of certain functions have changed between referenceOutput and output, e.g
> (0) 07:39:57 [impl::SolverInterfaceImpl]:**272** in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 

> (0) 16:22:15 [impl::SolverInterfaceImpl]:**264** in initialize: [0mit 1 of 40 | dt# 1 | t 0 of 1 | dt 0.01 | max dt 0.01 | ongoing yes | dt complete no | write-iteration-checkpoint | 

which the comparison script picks up on. Since this is not a breaking change, the text filter in the script has been appended to ignore such line numbers.