### PR TITLE
Set locale

### DIFF
--- a/precice/Dockerfile.Ubuntu1604.home
+++ b/precice/Dockerfile.Ubuntu1604.home
@@ -6,6 +6,7 @@ FROM ubuntu:16.04
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libxml2-dev \
     petsc-dev \
     git \

--- a/precice/Dockerfile.Ubuntu1604.home
+++ b/precice/Dockerfile.Ubuntu1604.home
@@ -34,15 +34,23 @@ RUN wget -nv 'https://downloads.sourceforge.net/project/boost/boost/1.65.1/boost
     ./b2 -j$(nproc) install && \
     rm -r /boost-build && \
     ldconfig
-
-ARG uid=1000
-ARG gid=1000
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
 # create user precice
+ARG uid=1000
+ARG gid=1000
 RUN groupadd -g ${gid} precice \
     && useradd -u ${uid} -g ${gid} -m -s /bin/bash precice
+
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+
 USER precice
 WORKDIR /home/precice
 

--- a/precice/Dockerfile.Ubuntu1604.package
+++ b/precice/Dockerfile.Ubuntu1604.package
@@ -38,6 +38,13 @@ RUN wget -nv 'https://downloads.sourceforge.net/project/boost/boost/1.65.1/boost
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice

--- a/precice/Dockerfile.Ubuntu1604.package
+++ b/precice/Dockerfile.Ubuntu1604.package
@@ -6,6 +6,7 @@ FROM ubuntu:16.04
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libxml2-dev \
     petsc-dev \
     git \

--- a/precice/Dockerfile.Ubuntu1604.sudo
+++ b/precice/Dockerfile.Ubuntu1604.sudo
@@ -38,6 +38,13 @@ RUN wget -nv 'https://downloads.sourceforge.net/project/boost/boost/1.65.1/boost
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice

--- a/precice/Dockerfile.Ubuntu1604.sudo
+++ b/precice/Dockerfile.Ubuntu1604.sudo
@@ -6,6 +6,7 @@ FROM ubuntu:16.04
 # Installing necessary dependacies for preCICE
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libxml2-dev \
     petsc-dev \
     git \

--- a/precice/Dockerfile.Ubuntu1804.home
+++ b/precice/Dockerfile.Ubuntu1804.home
@@ -6,6 +6,7 @@ FROM ubuntu:18.04
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libboost-all-dev \
     libeigen3-dev \
     libxml2-dev \
@@ -26,6 +27,17 @@ ARG uid=1000
 ARG gid=1000
 RUN groupadd -g ${gid} precice \
     && useradd -u ${uid} -g ${gid} -m -s /bin/bash precice
+
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN chown -R precice:precice /petsc
+USER precice
+
 USER precice
 WORKDIR /home/precice
 
@@ -46,6 +58,7 @@ WORKDIR /home/precice/precice
 ARG petsc_para=no
 ARG mpi_para=yes
 ARG python_para=no
+
 # Build preCICE and clean-up generated object files
 RUN mkdir /home/precice/precice-build && \
     cd /home/precice/precice-build && \

--- a/precice/Dockerfile.Ubuntu1804.package
+++ b/precice/Dockerfile.Ubuntu1804.package
@@ -6,6 +6,7 @@ FROM ubuntu:18.04
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libboost-all-dev \
     libeigen3-dev \
     libxml2-dev \

--- a/precice/Dockerfile.Ubuntu1804.package
+++ b/precice/Dockerfile.Ubuntu1804.package
@@ -21,6 +21,13 @@ RUN apt-get -qq update && apt-get -qq install \
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice

--- a/precice/Dockerfile.Ubuntu1804.sudo
+++ b/precice/Dockerfile.Ubuntu1804.sudo
@@ -6,6 +6,7 @@ FROM ubuntu:18.04
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libboost-all-dev \
     libeigen3-dev \
     libxml2-dev \

--- a/precice/Dockerfile.Ubuntu1804.sudo
+++ b/precice/Dockerfile.Ubuntu1804.sudo
@@ -21,6 +21,13 @@ RUN apt-get -qq update && apt-get -qq install \
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice

--- a/precice/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/precice/Dockerfile.Ubuntu1804.sudo.mpich
@@ -6,6 +6,7 @@ FROM ubuntu:18.04
 # Installing necessary dependacies for preCICE, boost 1.65 from apt-get
 RUN apt-get -qq update && apt-get -qq install \
     build-essential \
+    locales \
     libboost-all-dev \
     libeigen3-dev \
     libxml2-dev \

--- a/precice/Dockerfile.Ubuntu1804.sudo.mpich
+++ b/precice/Dockerfile.Ubuntu1804.sudo.mpich
@@ -22,6 +22,13 @@ RUN apt-get -qq update && apt-get -qq install \
 # Rebuild image if force_rebuild after that command
 ARG CACHEBUST
 
+# set locale
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # create user precice
 RUN useradd -ms /bin/bash precice
 USER precice


### PR DESCRIPTION
Adds a step in each of the Ubuntu-based preCICE dockerfiles to set the locale to `en_US.UTF-8`. This resolves [errors during the preCICE installation](https://travis-ci.org/github/precice/systemtests/builds/709788440) that have started appearing recently.